### PR TITLE
Refactor create_event and update_event for consistent API + enable all-day events

### DIFF
--- a/__tests__/all-day-events.test.js
+++ b/__tests__/all-day-events.test.js
@@ -1,0 +1,102 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { formatEvent } from '../src/formatters.js';
+
+// --- Mock tsdavManager for create-event handler tests ---
+const mockCreateCalendarObject = jest.fn().mockResolvedValue({ url: 'http://example.com/event.ics', etag: '"abc"' });
+const mockFetchCalendars = jest.fn().mockResolvedValue([{ url: 'https://example.com/calendar/' }]);
+
+jest.unstable_mockModule('../src/tsdav-client.js', () => ({
+  tsdavManager: {
+    getCalDavClient: () => ({
+      fetchCalendars: mockFetchCalendars,
+      createCalendarObject: mockCreateCalendarObject,
+    }),
+  },
+}));
+
+const { createEvent } = await import('../src/tools/calendar/create-event.js');
+
+const makeAllDayICal = (dtstart, dtend, summary = 'My Birthday') => [
+  'BEGIN:VCALENDAR',
+  'VERSION:2.0',
+  'PRODID:-//test//EN',
+  'BEGIN:VEVENT',
+  'UID:test-allday@example.com',
+  `DTSTART;VALUE=DATE:${dtstart}`,
+  `DTEND;VALUE=DATE:${dtend}`,
+  `SUMMARY:${summary}`,
+  'END:VEVENT',
+  'END:VCALENDAR',
+].join('\r\n');
+
+describe('All-day event formatting', () => {
+  test('formatEvent should show date only (no time) for VALUE=DATE events', () => {
+    const icalData = makeAllDayICal('20260525', '20260526');
+    const result = formatEvent({ data: icalData, url: 'https://example.com/event.ics' });
+    expect(result).toContain('May 25, 2026');
+    expect(result).not.toMatch(/\d{1,2}:\d{2}/);
+  });
+
+  test('formatEvent should not contain AM/PM for all-day events', () => {
+    const icalData = makeAllDayICal('20260101', '20260102');
+    const result = formatEvent({ data: icalData, url: 'https://example.com/event.ics' });
+    expect(result).not.toMatch(/AM|PM/);
+  });
+
+  test('formatEvent should not contain UTC timezone label for all-day events', () => {
+    const icalData = makeAllDayICal('20261225', '20261226', 'Christmas');
+    const result = formatEvent({ data: icalData, url: 'https://example.com/event.ics' });
+    expect(result).toContain('December 25, 2026');
+    expect(result).not.toContain('UTC');
+  });
+});
+
+describe('create_event iCal generation', () => {
+  const baseArgs = {
+    calendar_url: 'https://example.com/calendar/',
+    summary: 'Test Event',
+  };
+
+  beforeEach(() => mockCreateCalendarObject.mockClear());
+
+  test('date-only start_date auto-detects all-day and emits VALUE=DATE with next-day DTEND', async () => {
+    await createEvent.handler({ ...baseArgs, start_date: '2026-04-26', end_date: '2026-04-27' });
+    const { iCalString } = mockCreateCalendarObject.mock.calls[0][0];
+    expect(iCalString).toContain('DTSTART;VALUE=DATE:20260426');
+    expect(iCalString).toContain('DTEND;VALUE=DATE:20260427');
+    expect(iCalString).not.toMatch(/^DTSTART:\d{8}T/m);
+    expect(iCalString).not.toMatch(/^DTEND:\d{8}T/m);
+  });
+
+  test('all_day:true with datetime strings fails validation with clear error', async () => {
+    await expect(createEvent.handler({
+      ...baseArgs,
+      start_date: '2026-04-26T00:00:00Z',
+      end_date: '2026-04-26T23:59:59',
+      all_day: true,
+    })).rejects.toThrow('YYYY-MM-DD');
+  });
+
+  test('all_day:true with multi-day date-only range emits correct VALUE=DATE span', async () => {
+    await createEvent.handler({
+      ...baseArgs,
+      start_date: '2026-04-26',
+      end_date: '2026-04-28',
+      all_day: true,
+    });
+    const { iCalString } = mockCreateCalendarObject.mock.calls[0][0];
+    expect(iCalString).toContain('DTSTART;VALUE=DATE:20260426');
+    expect(iCalString).toContain('DTEND;VALUE=DATE:20260428');
+  });
+
+  test('timed event emits plain DTSTART/DTEND without VALUE=DATE', async () => {
+    await createEvent.handler({
+      ...baseArgs,
+      start_date: '2026-04-26T10:00:00Z',
+      end_date: '2026-04-26T11:00:00Z',
+    });
+    const { iCalString } = mockCreateCalendarObject.mock.calls[0][0];
+    expect(iCalString).toContain('DTSTART:20260426T100000Z');
+    expect(iCalString).not.toContain('VALUE=DATE');
+  });
+});

--- a/__tests__/handler-parameter-names.test.js
+++ b/__tests__/handler-parameter-names.test.js
@@ -140,7 +140,7 @@ describe('Error propagation (no internal try-catch)', () => {
       updateEventFields.handler({
         event_url: 'http://example.com/cal/event.ics',
         event_etag: '"etag-123"',
-        fields: { SUMMARY: 'x' },
+        summary: 'x',
       })
     ).rejects.toThrow('Server down');
   });
@@ -184,7 +184,7 @@ describe('Event handler: calendarObject parameter name', () => {
     await updateEventFields.handler({
       event_url: 'http://example.com/cal/event.ics',
       event_etag: '"etag-123"',
-      fields: { SUMMARY: 'Updated' },
+      summary: 'Updated',
     });
 
     expect(mockUpdateCalendarObject).toHaveBeenCalledTimes(1);
@@ -193,6 +193,47 @@ describe('Event handler: calendarObject parameter name', () => {
     expect(callArg).toHaveProperty('calendarObject');
     expect(callArg.calendarObject.url).toBe('http://example.com/cal/event.ics');
     expect(callArg.calendarObject.etag).toBe('"etag-123"');
+  });
+});
+
+describe('update_event all_day flag', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('transforms start_date/end_date to VALUE=DATE keys when all_day: true', async () => {
+    await updateEventFields.handler({
+      event_url: 'http://example.com/cal/event.ics',
+      event_etag: '"etag-123"',
+      all_day: true,
+      start_date: '2026-05-25',
+      end_date: '2026-05-26',
+    });
+    const fieldsPassedToUpdateFields = mockUpdateFields.mock.calls[0][1];
+    expect(fieldsPassedToUpdateFields).toHaveProperty('DTSTART;VALUE=DATE', '20260525');
+    expect(fieldsPassedToUpdateFields).toHaveProperty('DTEND;VALUE=DATE', '20260526');
+    expect(fieldsPassedToUpdateFields).not.toHaveProperty('DTSTART');
+    expect(fieldsPassedToUpdateFields).not.toHaveProperty('DTEND');
+  });
+
+  test('rejects all_day: true with datetime start_date', async () => {
+    await expect(
+      updateEventFields.handler({
+        event_url: 'http://example.com/cal/event.ics',
+        event_etag: '"etag-123"',
+        all_day: true,
+        start_date: '2026-05-25T00:00:00Z',
+        end_date: '2026-05-26',
+      })
+    ).rejects.toThrow('YYYY-MM-DD');
+  });
+
+  test('passes named params as UPPERCASE fields when all_day is not set', async () => {
+    await updateEventFields.handler({
+      event_url: 'http://example.com/cal/event.ics',
+      event_etag: '"etag-123"',
+      summary: 'Updated title',
+    });
+    const fieldsPassedToUpdateFields = mockUpdateFields.mock.calls[0][1];
+    expect(fieldsPassedToUpdateFields).toHaveProperty('SUMMARY', 'Updated title');
   });
 });
 

--- a/__tests__/recurring-dst.test.js
+++ b/__tests__/recurring-dst.test.js
@@ -1,0 +1,94 @@
+import { describe, test, expect } from '@jest/globals';
+import { formatEvent, formatEventList } from '../src/formatters.js';
+
+// Master VEVENT for a MWF recurring event created in January (EST = UTC-5).
+// The server returns this master event even for April time-range queries.
+const RECURRING_EST_ICAL = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VTIMEZONE
+TZID:America/New_York
+BEGIN:DAYLIGHT
+TZNAME:EDT
+TZOFFSETFROM:-0500
+TZOFFSETTO:-0400
+DTSTART:19700308T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZNAME:EST
+TZOFFSETFROM:-0400
+TZOFFSETTO:-0500
+DTSTART:19701101T020000
+RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:test-recurring-dst@example.com
+SUMMARY:Lab Software: Discovery
+DTSTART;TZID=America/New_York:20260121T060000
+DTEND;TZID=America/New_York:20260121T063000
+RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR
+END:VEVENT
+END:VCALENDAR`;
+
+const makeEvent = (data) => ({ url: 'https://example.com/event.ics', etag: '"1"', data });
+
+describe('recurring event DST display', () => {
+  test('without timeRange: shows master DTSTART (January)', () => {
+    const output = formatEvent(makeEvent(RECURRING_EST_ICAL), 'Test Calendar');
+    expect(output).toContain('January 21, 2026');
+  });
+
+  test('with April timeRange: shows April occurrence, not January', () => {
+    const timeRange = { start: '2026-04-22T00:00:00Z', end: '2026-04-29T00:00:00Z' };
+    const output = formatEvent(makeEvent(RECURRING_EST_ICAL), 'Test Calendar', timeRange);
+    expect(output).not.toContain('January');
+    // First MWF occurrence in Apr 22–29 is Wednesday Apr 22
+    expect(output).toContain('April 22, 2026');
+  });
+
+  test('with April timeRange: shows EDT offset (UTC-4), not EST (UTC-5)', () => {
+    const timeRange = { start: '2026-04-22T00:00:00Z', end: '2026-04-29T00:00:00Z' };
+    const output = formatEvent(makeEvent(RECURRING_EST_ICAL), 'Test Calendar', timeRange);
+    // 6 AM EDT should display with EDT abbreviation
+    expect(output).toContain('EDT');
+    expect(output).not.toContain('EST');
+  });
+
+  test('with April timeRange: correct local time (6:00 AM)', () => {
+    const timeRange = { start: '2026-04-22T00:00:00Z', end: '2026-04-29T00:00:00Z' };
+    const output = formatEvent(makeEvent(RECURRING_EST_ICAL), 'Test Calendar', timeRange);
+    expect(output).toContain('6:00 AM');
+  });
+
+  test('formatEventList passes timeRange to each event', () => {
+    const timeRange = { start: '2026-04-22T00:00:00Z', end: '2026-04-29T00:00:00Z' };
+    const result = formatEventList([makeEvent(RECURRING_EST_ICAL)], 'Test Calendar', timeRange);
+    expect(result.content[0].text).toContain('April 22, 2026');
+    expect(result.content[0].text).not.toContain('January');
+  });
+});
+
+describe('formatDateTime timezone display', () => {
+  test('UTC events still show UTC', () => {
+    const UTC_ICAL = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+UID:test-utc@example.com
+SUMMARY:UTC Event
+DTSTART:20260422T100000Z
+DTEND:20260422T110000Z
+END:VEVENT
+END:VCALENDAR`;
+    const output = formatEvent(makeEvent(UTC_ICAL), 'Test');
+    expect(output).toContain('UTC');
+  });
+
+  test('named-timezone events show that timezone abbreviation', () => {
+    const output = formatEvent(makeEvent(RECURRING_EST_ICAL), 'Test');
+    // Without timeRange, master DTSTART is Jan (EST)
+    expect(output).toMatch(/EST|EDT/);
+  });
+});

--- a/__tests__/validation.test.js
+++ b/__tests__/validation.test.js
@@ -107,6 +107,61 @@ describe('Validation Module', () => {
     });
   });
 
+  describe('All-day event support', () => {
+    test('should accept date-only start/end for all-day event', () => {
+      const input = {
+        calendar_url: 'https://example.com/calendar/',
+        summary: 'My Birthday',
+        start_date: '2026-05-25',
+        end_date: '2026-05-26',
+        all_day: true,
+      };
+      expect(() => validateInput(createEventSchema, input)).not.toThrow();
+    });
+
+    test('should accept date-only strings without all_day flag (auto-detect)', () => {
+      const input = {
+        calendar_url: 'https://example.com/calendar/',
+        summary: 'Public Holiday',
+        start_date: '2026-12-25',
+        end_date: '2026-12-26',
+      };
+      expect(() => validateInput(createEventSchema, input)).not.toThrow();
+    });
+
+    test('should reject datetime strings with all_day: true — must use YYYY-MM-DD', () => {
+      const input = {
+        calendar_url: 'https://example.com/calendar/',
+        summary: 'Birthday Party',
+        start_date: '2026-05-25T00:00:00Z',
+        end_date: '2026-05-26T00:00:00Z',
+        all_day: true,
+      };
+      expect(() => validateInput(createEventSchema, input)).toThrow('YYYY-MM-DD');
+    });
+
+    test('should reject mixed date-only start + datetime end (auto-detected as all-day)', () => {
+      const input = {
+        calendar_url: 'https://example.com/calendar/',
+        summary: 'Bad Mix',
+        start_date: '2026-05-25',
+        end_date: '2026-05-26T23:59:59',
+      };
+      expect(() => validateInput(createEventSchema, input)).toThrow('YYYY-MM-DD');
+    });
+
+    test('should reject date-only string with end before start', () => {
+      const input = {
+        calendar_url: 'https://example.com/calendar/',
+        summary: 'Bad Event',
+        start_date: '2026-05-26',
+        end_date: '2026-05-25',
+        all_day: true,
+      };
+      expect(() => validateInput(createEventSchema, input)).toThrow();
+    });
+  });
+
   describe('optionalUrl preprocessing (LLM robustness)', () => {
     describe('calendarQuerySchema', () => {
       test('should accept valid URL', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dav-mcp",
-  "version": "3.0.1",
+  "version": "3.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dav-mcp",
-      "version": "3.0.1",
+      "version": "3.0.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.3",

--- a/src/formatters.js
+++ b/src/formatters.js
@@ -141,6 +141,15 @@ function formatDateTime(icalTime) {
   if (!icalTime) return '';
 
   try {
+    if (icalTime.isDate) {
+      return icalTime.toJSDate().toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        timeZone: 'UTC',
+      });
+    }
+
     // Convert ICAL.Time to JavaScript Date
     const jsDate = icalTime.toJSDate();
 

--- a/src/formatters.js
+++ b/src/formatters.js
@@ -13,11 +13,6 @@ import ICAL from 'ical.js';
 
 /**
  * Parse iCal data string to extract event properties (RFC 5545 compliant)
- *
- * @param {string} icalData - Raw iCalendar text
- * @param {{ start: ICAL.Time, end: ICAL.Time } | null} targetRange - When provided and the
- *   event is recurring, expands the RRULE to find the first occurrence within the range so
- *   the displayed "When" reflects the actual queried occurrence rather than the master DTSTART.
  */
 function parseICalEvent(icalData, targetRange = null) {
   try {
@@ -177,9 +172,7 @@ function formatDateTime(icalTime) {
 
     // Convert ICAL.Time to JavaScript Date
     const jsDate = icalTime.toJSDate();
-    // ical.js v2 stores timezone as icalTime.zone.tzid (an ICAL.Timezone object),
-    // not as the deprecated icalTime.timezone string property.
-    // Fall back to UTC for floating times or if no zone is set.
+    // ical.js v2: timezone lives in zone.tzid, not the deprecated timezone property.
     const tzid = icalTime.zone?.tzid;
     const tz = (tzid && tzid !== 'floating') ? tzid : 'UTC';
 

--- a/src/formatters.js
+++ b/src/formatters.js
@@ -13,8 +13,13 @@ import ICAL from 'ical.js';
 
 /**
  * Parse iCal data string to extract event properties (RFC 5545 compliant)
+ *
+ * @param {string} icalData - Raw iCalendar text
+ * @param {{ start: ICAL.Time, end: ICAL.Time } | null} targetRange - When provided and the
+ *   event is recurring, expands the RRULE to find the first occurrence within the range so
+ *   the displayed "When" reflects the actual queried occurrence rather than the master DTSTART.
  */
-function parseICalEvent(icalData) {
+function parseICalEvent(icalData, targetRange = null) {
   try {
     const jcalData = ICAL.parse(icalData);
     const comp = new ICAL.Component(jcalData);
@@ -26,13 +31,33 @@ function parseICalEvent(icalData) {
 
     const event = new ICAL.Event(vevent);
 
+    let dtstart = event.startDate;
+    let dtend = event.endDate;
+
+    if (event.isRecurring() && targetRange) {
+      const expand = new ICAL.RecurExpansion({
+        component: vevent,
+        dtstart: event.startDate,
+      });
+      let occ;
+      while ((occ = expand.next())) {
+        if (occ.compare(targetRange.end) > 0) break;
+        if (occ.compare(targetRange.start) >= 0) {
+          dtstart = occ;
+          dtend = occ.clone();
+          dtend.addDuration(event.duration);
+          break;
+        }
+      }
+    }
+
     return {
       summary: event.summary || '',
       description: event.description || '',
       location: event.location || '',
       uid: event.uid || '',
-      dtstart: event.startDate,
-      dtend: event.endDate,
+      dtstart,
+      dtend,
       isRecurring: event.isRecurring(),
       rrule: event.isRecurring() ? vevent.getFirstPropertyValue('rrule') : null,
       organizer: vevent.getFirstPropertyValue('organizer'),
@@ -152,19 +177,24 @@ function formatDateTime(icalTime) {
 
     // Convert ICAL.Time to JavaScript Date
     const jsDate = icalTime.toJSDate();
+    // ical.js v2 stores timezone as icalTime.zone.tzid (an ICAL.Timezone object),
+    // not as the deprecated icalTime.timezone string property.
+    // Fall back to UTC for floating times or if no zone is set.
+    const tzid = icalTime.zone?.tzid;
+    const tz = (tzid && tzid !== 'floating') ? tzid : 'UTC';
 
     const dateStr = jsDate.toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'long',
       day: 'numeric',
-      timeZone: icalTime.timezone === 'UTC' ? 'UTC' : undefined,
+      timeZone: tz,
     });
 
     const timeStr = jsDate.toLocaleTimeString('en-US', {
       hour: '2-digit',
       minute: '2-digit',
       timeZoneName: 'short',
-      timeZone: icalTime.timezone === 'UTC' ? 'UTC' : undefined,
+      timeZone: tz,
     });
 
     return `${dateStr}, ${timeStr}`;
@@ -177,8 +207,12 @@ function formatDateTime(icalTime) {
 /**
  * Format a single calendar event to Markdown
  */
-export function formatEvent(event, calendarName = 'Unknown Calendar') {
-  const parsed = parseICalEvent(event.data);
+export function formatEvent(event, calendarName = 'Unknown Calendar', timeRange = null) {
+  const targetRange = timeRange ? {
+    start: ICAL.Time.fromDateTimeString(timeRange.start),
+    end: ICAL.Time.fromDateTimeString(timeRange.end),
+  } : null;
+  const parsed = parseICalEvent(event.data, targetRange);
 
   const startDate = formatDateTime(parsed.dtstart);
   const endDate = formatDateTime(parsed.dtend);
@@ -238,7 +272,7 @@ export function formatEvent(event, calendarName = 'Unknown Calendar') {
 /**
  * Format a list of calendar events to LLM-friendly Markdown
  */
-export function formatEventList(events, calendarName = 'Unknown Calendar') {
+export function formatEventList(events, calendarName = 'Unknown Calendar', timeRange = null) {
   if (!events || events.length === 0) {
     return {
       content: [{
@@ -252,7 +286,7 @@ export function formatEventList(events, calendarName = 'Unknown Calendar') {
 
   events.forEach((event, index) => {
     output += `### ${index + 1}. `;
-    output += formatEvent(event, calendarName).replace(/^## /, '') + '\n';
+    output += formatEvent(event, calendarName, timeRange).replace(/^## /, '') + '\n';
   });
 
   output += `---\n<details>\n<summary>Raw Data (JSON)</summary>\n\n\`\`\`json\n`;

--- a/src/tools/calendar/calendar-query.js
+++ b/src/tools/calendar/calendar-query.js
@@ -93,6 +93,11 @@ export const calendarQuery = {
       ? (calendarsToSearch[0].displayName || calendarsToSearch[0].url)
       : `All Calendars (${calendarsToSearch.length})`;
 
-    return formatEventList(filteredEvents, calendarName);
+    const timeRange = validated.time_range_start ? {
+      start: validated.time_range_start,
+      end: validated.time_range_end,
+    } : null;
+
+    return formatEventList(filteredEvents, calendarName, timeRange);
   },
 };

--- a/src/tools/calendar/create-event.js
+++ b/src/tools/calendar/create-event.js
@@ -22,11 +22,15 @@ export const createEvent = {
       },
       start_date: {
         type: 'string',
-        description: 'Start date in ISO 8601 format',
+        description: 'Start date. Use ISO 8601 datetime (e.g., "2026-05-25T10:00:00Z") for timed events, or YYYY-MM-DD (e.g., "2026-05-25") for all-day events.',
       },
       end_date: {
         type: 'string',
-        description: 'End date in ISO 8601 format',
+        description: 'End date. Use ISO 8601 datetime for timed events, or YYYY-MM-DD for all-day events. For a single all-day event, set end_date to the next day (e.g., start "2026-05-25", end "2026-05-26").',
+      },
+      all_day: {
+        type: 'boolean',
+        description: 'Set to true to create an all-day event. Can be omitted when start_date/end_date are in YYYY-MM-DD format — the format is auto-detected.',
       },
       description: {
         type: 'string',
@@ -35,6 +39,11 @@ export const createEvent = {
       location: {
         type: 'string',
         description: 'Event location (optional)',
+      },
+      extra_fields: {
+        type: 'object',
+        description: 'Additional RFC 5545 (https://www.rfc-editor.org/rfc/rfc5545) properties to include, keyed by UPPERCASE property name. Use for RRULE, ATTENDEE, X-* custom properties, etc.',
+        additionalProperties: { type: 'string' },
       },
     },
     required: ['calendar_url', 'summary', 'start_date', 'end_date'],
@@ -52,15 +61,29 @@ export const createEvent = {
     const description = validated.description ? sanitizeICalString(validated.description) : '';
     const location = validated.location ? sanitizeICalString(validated.location) : '';
 
+    const isAllDay = validated.all_day || /^\d{4}-\d{2}-\d{2}$/.test(validated.start_date);
+    let dtstart, dtend;
+    if (isAllDay) {
+      dtstart = `DTSTART;VALUE=DATE:${validated.start_date.replace(/-/g, '')}`;
+      dtend = `DTEND;VALUE=DATE:${validated.end_date.replace(/-/g, '')}`;
+    } else {
+      dtstart = `DTSTART:${formatICalDate(new Date(validated.start_date))}`;
+      dtend = `DTEND:${formatICalDate(new Date(validated.end_date))}`;
+    }
+
+    const extraLines = validated.extra_fields
+      ? Object.entries(validated.extra_fields).map(([k, v]) => `${k}:${v}`).join('\n')
+      : '';
+
     const iCalString = `BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//tsdav-mcp-server//EN
 BEGIN:VEVENT
 UID:${uid}
 DTSTAMP:${formatICalDate(now)}
-DTSTART:${formatICalDate(new Date(validated.start_date))}
-DTEND:${formatICalDate(new Date(validated.end_date))}
-SUMMARY:${summary}${description ? `\nDESCRIPTION:${description}` : ''}${location ? `\nLOCATION:${location}` : ''}
+${dtstart}
+${dtend}
+SUMMARY:${summary}${description ? `\nDESCRIPTION:${description}` : ''}${location ? `\nLOCATION:${location}` : ''}${extraLines ? `\n${extraLines}` : ''}
 END:VEVENT
 END:VCALENDAR`;
 

--- a/src/tools/calendar/list-events.js
+++ b/src/tools/calendar/list-events.js
@@ -38,6 +38,11 @@ export const listEvents = {
 
     const events = await client.fetchCalendarObjects(options);
 
-    return formatEventList(events, calendar);
+    const timeRange = validated.time_range_start ? {
+      start: validated.time_range_start,
+      end: validated.time_range_end,
+    } : null;
+
+    return formatEventList(events, calendar, timeRange);
   },
 };

--- a/src/tools/calendar/update-event-fields.js
+++ b/src/tools/calendar/update-event-fields.js
@@ -1,33 +1,13 @@
 import { tsdavManager } from '../../tsdav-client.js';
-import { validateInput } from '../../validation.js';
+import { validateInput, updateEventFieldsSchema, sanitizeICalString } from '../../validation.js';
 import { formatSuccess } from '../../formatters.js';
-import { z } from 'zod';
 import { updateFields } from 'tsdav-utils';
 
-/**
- * Schema for field-based event updates
- * Supports all RFC 5545 iCalendar properties via tsdav-utils
- * Common fields: SUMMARY, DESCRIPTION, LOCATION, DTSTART, DTEND, STATUS
- * Custom properties: Any X-* property
- */
-const updateEventFieldsSchema = z.object({
-  event_url: z.string().url('Event URL must be a valid URL'),
-  event_etag: z.string().min(1, 'Event etag is required'),
-  fields: z.record(z.string()).optional()
-});
+const dateOnlyPattern = /^\d{4}-\d{2}-\d{2}$/;
 
-/**
- * Field-agnostic event update tool powered by tsdav-utils
- * Supports all RFC 5545 iCalendar properties without validation
- *
- * Features:
- * - Any standard VEVENT property (SUMMARY, DESCRIPTION, LOCATION, DTSTART, etc.)
- * - Custom X-* properties for extensions
- * - Field-agnostic: no pre-defined field list required
- */
 export const updateEventFields = {
   name: 'update_event',
-  description: 'PREFERRED: Update event fields without iCal formatting. Supports: SUMMARY (title), DESCRIPTION (details), LOCATION (place), DTSTART (start time), DTEND (end time), STATUS (TENTATIVE/CONFIRMED/CANCELLED), and any RFC 5545 property including custom X-* properties (e.g., X-ZOOM-LINK, X-MEETING-ROOM).',
+  description: 'PREFERRED: Update specific fields of a calendar event. All parameters are optional except event_url and event_etag — only provided fields are changed. Use extra_fields for any RFC 5545 (https://www.rfc-editor.org/rfc/rfc5545) property not covered by named params (e.g. RRULE, ATTENDEE, X-* custom properties).',
   inputSchema: {
     type: 'object',
     properties: {
@@ -39,38 +19,39 @@ export const updateEventFields = {
         type: 'string',
         description: 'The etag of the event (required for conflict detection)'
       },
-      fields: {
+      summary: {
+        type: 'string',
+        description: 'Event title'
+      },
+      description: {
+        type: 'string',
+        description: 'Event description/details'
+      },
+      location: {
+        type: 'string',
+        description: 'Physical or virtual meeting location'
+      },
+      start_date: {
+        type: 'string',
+        description: 'Start date. ISO 8601 datetime (e.g. "2026-05-25T10:00:00Z") for timed events, or YYYY-MM-DD (e.g. "2026-05-25") for all-day events.'
+      },
+      end_date: {
+        type: 'string',
+        description: 'End date. ISO 8601 datetime for timed events, or YYYY-MM-DD for all-day events. Exclusive end — for a single all-day event set end_date to the next day.'
+      },
+      all_day: {
+        type: 'boolean',
+        description: 'Convert to/from all-day event. When true, start_date and end_date must be in YYYY-MM-DD format. Can be omitted when the date format is unambiguous.'
+      },
+      status: {
+        type: 'string',
+        enum: ['TENTATIVE', 'CONFIRMED', 'CANCELLED'],
+        description: 'Event status'
+      },
+      extra_fields: {
         type: 'object',
-        description: 'Fields to update - use UPPERCASE property names (e.g., SUMMARY, LOCATION, DTSTART). Any RFC 5545 property or custom X-* property is supported.',
-        additionalProperties: {
-          type: 'string'
-        },
-        properties: {
-          SUMMARY: {
-            type: 'string',
-            description: 'Event title/summary'
-          },
-          DESCRIPTION: {
-            type: 'string',
-            description: 'Event description/details'
-          },
-          LOCATION: {
-            type: 'string',
-            description: 'Physical or virtual meeting location'
-          },
-          DTSTART: {
-            type: 'string',
-            description: 'Start datetime (ISO 8601 or iCal format: 20250128T100000Z)'
-          },
-          DTEND: {
-            type: 'string',
-            description: 'End datetime (ISO 8601 or iCal format)'
-          },
-          STATUS: {
-            type: 'string',
-            description: 'Event status: TENTATIVE, CONFIRMED, or CANCELLED'
-          }
-        }
+        description: 'Additional RFC 5545 properties (https://www.rfc-editor.org/rfc/rfc5545) to set, keyed by UPPERCASE property name. Use for RRULE, ATTENDEE, X-* custom properties, etc.',
+        additionalProperties: { type: 'string' }
       }
     },
     required: ['event_url', 'event_etag']
@@ -79,7 +60,6 @@ export const updateEventFields = {
     const validated = validateInput(updateEventFieldsSchema, args);
     const client = tsdavManager.getCalDavClient();
 
-    // Step 1: Fetch the current event from server
     const calendarUrl = validated.event_url.substring(0, validated.event_url.lastIndexOf('/') + 1);
     const currentEvents = await client.fetchCalendarObjects({
       calendar: { url: calendarUrl },
@@ -92,11 +72,36 @@ export const updateEventFields = {
 
     const calendarObject = currentEvents[0];
 
-    // Step 2: Update fields using tsdav-utils (field-agnostic)
-    // Accepts any RFC 5545 property name (UPPERCASE)
-    const updatedData = updateFields(calendarObject, validated.fields || {});
+    const isAllDay = validated.all_day || (validated.start_date && dateOnlyPattern.test(validated.start_date));
 
-    // Step 3: Send the updated event back to server
+    const fields = {};
+
+    if (validated.summary !== undefined) fields.SUMMARY = sanitizeICalString(validated.summary);
+    if (validated.description !== undefined) fields.DESCRIPTION = sanitizeICalString(validated.description);
+    if (validated.location !== undefined) fields.LOCATION = sanitizeICalString(validated.location);
+    if (validated.status !== undefined) fields.STATUS = validated.status;
+
+    if (validated.start_date !== undefined) {
+      if (isAllDay) {
+        fields['DTSTART;VALUE=DATE'] = validated.start_date.replace(/-/g, '');
+      } else {
+        fields.DTSTART = validated.start_date;
+      }
+    }
+    if (validated.end_date !== undefined) {
+      if (isAllDay) {
+        fields['DTEND;VALUE=DATE'] = validated.end_date.replace(/-/g, '');
+      } else {
+        fields.DTEND = validated.end_date;
+      }
+    }
+
+    if (validated.extra_fields) {
+      Object.assign(fields, validated.extra_fields);
+    }
+
+    const updatedData = updateFields(calendarObject, fields);
+
     const updateResponse = await client.updateCalendarObject({
       calendarObject: {
         url: validated.event_url,
@@ -107,8 +112,8 @@ export const updateEventFields = {
 
     return formatSuccess('Event updated successfully', {
       etag: updateResponse.etag,
-      updated_fields: Object.keys(validated.fields || {}),
-      message: `Updated ${Object.keys(validated.fields || {}).length} field(s): ${Object.keys(validated.fields || {}).join(', ')}`
+      updated_fields: Object.keys(fields),
+      message: `Updated ${Object.keys(fields).length} field(s): ${Object.keys(fields).join(', ')}`
     });
   }
 };

--- a/src/validation.js
+++ b/src/validation.js
@@ -11,6 +11,9 @@ const dateTimeWithOptionalOffset = z.union([
   z.string().regex(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/, 'Invalid datetime format') // Without timezone
 ]);
 
+// Helper: Date-only string for all-day events (YYYY-MM-DD)
+const dateOnly = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date format (use YYYY-MM-DD for all-day events)');
+
 // Helper: Optional URL that gracefully handles LLM placeholder values
 // Transforms common LLM-generated placeholders ("", "unknown", "default", etc.) to undefined
 const optionalUrl = (message) =>
@@ -45,13 +48,44 @@ export const listEventsSchema = z.object({
 export const createEventSchema = z.object({
   calendar_url: z.string().url('Invalid calendar URL'),
   summary: z.string().min(1, 'Summary is required').max(500),
-  start_date: dateTimeWithOptionalOffset,
-  end_date: dateTimeWithOptionalOffset,
+  start_date: z.union([dateTimeWithOptionalOffset, dateOnly]),
+  end_date: z.union([dateTimeWithOptionalOffset, dateOnly]),
+  all_day: z.boolean().optional(),
   description: z.string().max(5000).optional(),
   location: z.string().max(500).optional(),
+  extra_fields: z.record(z.string()).optional(),
 }).refine((data) => new Date(data.end_date) > new Date(data.start_date), {
   message: 'End date must be after start date',
   path: ['end_date'],
+}).refine((data) => {
+  const isAllDay = data.all_day || /^\d{4}-\d{2}-\d{2}$/.test(data.start_date);
+  if (!isAllDay) return true;
+  return /^\d{4}-\d{2}-\d{2}$/.test(data.start_date) && /^\d{4}-\d{2}-\d{2}$/.test(data.end_date);
+}, {
+  message: 'All-day events require both start_date and end_date in YYYY-MM-DD format (e.g. "2026-05-25", "2026-05-26")',
+  path: ['end_date'],
+});
+
+export const updateEventFieldsSchema = z.object({
+  event_url: z.string().url('Event URL must be a valid URL'),
+  event_etag: z.string().min(1, 'Event etag is required'),
+  summary: z.string().min(1).max(500).optional(),
+  description: z.string().max(5000).optional(),
+  location: z.string().max(500).optional(),
+  start_date: z.union([dateTimeWithOptionalOffset, dateOnly]).optional(),
+  end_date: z.union([dateTimeWithOptionalOffset, dateOnly]).optional(),
+  all_day: z.boolean().optional(),
+  status: z.enum(['TENTATIVE', 'CONFIRMED', 'CANCELLED']).optional(),
+  extra_fields: z.record(z.string()).optional(),
+}).refine((data) => {
+  const isAllDay = data.all_day || (data.start_date && dateOnly.safeParse(data.start_date).success);
+  if (!isAllDay) return true;
+  if (data.start_date && !dateOnly.safeParse(data.start_date).success) return false;
+  if (data.end_date && !dateOnly.safeParse(data.end_date).success) return false;
+  return true;
+}, {
+  message: 'All-day events require start_date and end_date in YYYY-MM-DD format (e.g. "2026-05-25", "2026-05-26")',
+  path: ['start_date'],
 });
 
 export const updateEventSchema = z.object({


### PR DESCRIPTION
Claude coded, human tested with agents.

## Problem

Two bugs, one root cause.

**Bug 1 — All-day events didn't work at all in `create_event`.**  
The schema only accepted ISO 8601 datetime strings. Passing `start_date: "2026-05-25"` failed validation. Even if it had passed, the iCal builder always emitted `DTSTART:YYYYMMDDTHHmmssZ` — never `DTSTART;VALUE=DATE:YYYYMMDD`. The formatter also showed `May 25, 2026, 12:00:00 AM UTC` for VALUE=DATE events instead of just the date.

**Bug 2 — All-day events couldn't be updated either, for a different reason.**  
`update_event` had no all-day support. But the deeper issue was the API asymmetry: `create_event` used friendly snake_case params (`start_date`, `end_date`), while `update_event` exposed tsdav-utils internals directly via a raw `fields` dict requiring UPPERCASE iCal property names (`DTSTART`, `DTEND`, `SUMMARY`). When the all-day case was bolted onto `update_event`, it required `"DTSTART;VALUE=DATE": "20260525"` — a completely different format from what `create_event` accepted. Agents got it wrong silently; the calendar server rejected the iCal.

The asymmetry is the root cause. If `update_event` had used the same `start_date` param as `create_event` from the start, the all-day confusion never would have arisen.

## What this PR does

**Fixes the formatter** so VALUE=DATE events display as `May 25, 2026` with no time component.

**Fixes `create_event`** to accept `YYYY-MM-DD` date-only strings, auto-detect all-day from the format, and emit `DTSTART;VALUE=DATE:YYYYMMDD` correctly. An explicit `all_day: true` flag is also accepted but not required.

**Unifies the API** by giving `update_event` the same named snake_case params as `create_event`, all optional (patch semantics). The UPPERCASE↔tsdav-utils mapping is now an internal detail.

```
create_event:  summary, start_date, end_date, all_day, description, location, extra_fields
update_event:  summary, start_date, end_date, all_day, description, location, extra_fields, status
```

`update_event` additionally gains `status` (`TENTATIVE | CONFIRMED | CANCELLED`) since changing event status is a natural update operation with no equivalent on create.

Both tools gain `extra_fields: Record<string, string>` as an RFC 5545 escape hatch for properties not covered by named params (RRULE, ATTENDEE, X-* custom properties). The tool description links to the RFC so agents know the full vocabulary.

`update_event_raw` (full iCal PUT, no fetch-first) is retained unchanged.

## “Breaking” change

`update_event` no longer accepts the `fields` dict. Any system prompt or workflow that hardcodes `fields: { SUMMARY: "..." }` will fail.

**Severity in practice:** Low. MCP tools are called by LLMs, not compiled code. Every session the LLM reads the live `inputSchema`, adapts to whatever is there, and moves on. There is no version pinning or SDK client. The only hard break is a saved system prompt containing literal `"fields": {` in a CalDAV instruction — and even then, the LLM will fail once, read the validation error, and self-correct from the new description.

## Version recommendation

By strict [SemVer](https://semver.org/), removing a parameter is a breaking change → **4.0.0**.

The counter-argument: MCP tool schemas aren't versioned contracts the way REST APIs are — the client (an LLM) adapts dynamically, so "breaking" means something different here. Under that view, **3.1.0** is defensible.

I'd recommend **4.0.0** for two reasons: (1) the project clearly tracks versions carefully — a deliberate API rename deserves a major bump as a clear signal in the changelog; (2) if any user has a system prompt with `fields: {...}` instructions, a major version bump gives them an obvious place to look.

## Open questions

1. **Is the API unification worth the breaking change?** The motivation is reducing LLM confusion — agents no longer need to know two vocabularies for the same entity. Hard to measure, but the all-day bug is a concrete example of where the asymmetry caused real failures.
2. **All-day TODO support** is still missing: `create-todo` always emits a datetime for `due_date`, and `todo-query` can't filter by date-only DUE properties. Pre-existing gaps, not introduced here — worth filing as separate issues?
