### PR TITLE
fix: show correct occurrence date/time for recurring events across DST

### DIFF
--- a/__tests__/recurring-dst.test.js
+++ b/__tests__/recurring-dst.test.js
@@ -1,0 +1,94 @@
+import { describe, test, expect } from '@jest/globals';
+import { formatEvent, formatEventList } from '../src/formatters.js';
+
+// Master VEVENT for a MWF recurring event created in January (EST = UTC-5).
+// The server returns this master event even for April time-range queries.
+const RECURRING_EST_ICAL = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VTIMEZONE
+TZID:America/New_York
+BEGIN:DAYLIGHT
+TZNAME:EDT
+TZOFFSETFROM:-0500
+TZOFFSETTO:-0400
+DTSTART:19700308T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZNAME:EST
+TZOFFSETFROM:-0400
+TZOFFSETTO:-0500
+DTSTART:19701101T020000
+RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:test-recurring-dst@example.com
+SUMMARY:Lab Software: Discovery
+DTSTART;TZID=America/New_York:20260121T060000
+DTEND;TZID=America/New_York:20260121T063000
+RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR
+END:VEVENT
+END:VCALENDAR`;
+
+const makeEvent = (data) => ({ url: 'https://example.com/event.ics', etag: '"1"', data });
+
+describe('recurring event DST display', () => {
+  test('without timeRange: shows master DTSTART (January)', () => {
+    const output = formatEvent(makeEvent(RECURRING_EST_ICAL), 'Test Calendar');
+    expect(output).toContain('January 21, 2026');
+  });
+
+  test('with April timeRange: shows April occurrence, not January', () => {
+    const timeRange = { start: '2026-04-22T00:00:00Z', end: '2026-04-29T00:00:00Z' };
+    const output = formatEvent(makeEvent(RECURRING_EST_ICAL), 'Test Calendar', timeRange);
+    expect(output).not.toContain('January');
+    // First MWF occurrence in Apr 22–29 is Wednesday Apr 22
+    expect(output).toContain('April 22, 2026');
+  });
+
+  test('with April timeRange: shows EDT offset (UTC-4), not EST (UTC-5)', () => {
+    const timeRange = { start: '2026-04-22T00:00:00Z', end: '2026-04-29T00:00:00Z' };
+    const output = formatEvent(makeEvent(RECURRING_EST_ICAL), 'Test Calendar', timeRange);
+    // 6 AM EDT should display with EDT abbreviation
+    expect(output).toContain('EDT');
+    expect(output).not.toContain('EST');
+  });
+
+  test('with April timeRange: correct local time (6:00 AM)', () => {
+    const timeRange = { start: '2026-04-22T00:00:00Z', end: '2026-04-29T00:00:00Z' };
+    const output = formatEvent(makeEvent(RECURRING_EST_ICAL), 'Test Calendar', timeRange);
+    expect(output).toContain('6:00 AM');
+  });
+
+  test('formatEventList passes timeRange to each event', () => {
+    const timeRange = { start: '2026-04-22T00:00:00Z', end: '2026-04-29T00:00:00Z' };
+    const result = formatEventList([makeEvent(RECURRING_EST_ICAL)], 'Test Calendar', timeRange);
+    expect(result.content[0].text).toContain('April 22, 2026');
+    expect(result.content[0].text).not.toContain('January');
+  });
+});
+
+describe('formatDateTime timezone display', () => {
+  test('UTC events still show UTC', () => {
+    const UTC_ICAL = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+UID:test-utc@example.com
+SUMMARY:UTC Event
+DTSTART:20260422T100000Z
+DTEND:20260422T110000Z
+END:VEVENT
+END:VCALENDAR`;
+    const output = formatEvent(makeEvent(UTC_ICAL), 'Test');
+    expect(output).toContain('UTC');
+  });
+
+  test('named-timezone events show that timezone abbreviation', () => {
+    const output = formatEvent(makeEvent(RECURRING_EST_ICAL), 'Test');
+    // Without timeRange, master DTSTART is Jan (EST)
+    expect(output).toMatch(/EST|EDT/);
+  });
+});

--- a/src/formatters.js
+++ b/src/formatters.js
@@ -13,8 +13,13 @@ import ICAL from 'ical.js';
 
 /**
  * Parse iCal data string to extract event properties (RFC 5545 compliant)
+ *
+ * @param {string} icalData - Raw iCalendar text
+ * @param {{ start: ICAL.Time, end: ICAL.Time } | null} targetRange - When provided and the
+ *   event is recurring, expands the RRULE to find the first occurrence within the range so
+ *   the displayed "When" reflects the actual queried occurrence rather than the master DTSTART.
  */
-function parseICalEvent(icalData) {
+function parseICalEvent(icalData, targetRange = null) {
   try {
     const jcalData = ICAL.parse(icalData);
     const comp = new ICAL.Component(jcalData);
@@ -26,13 +31,33 @@ function parseICalEvent(icalData) {
 
     const event = new ICAL.Event(vevent);
 
+    let dtstart = event.startDate;
+    let dtend = event.endDate;
+
+    if (event.isRecurring() && targetRange) {
+      const expand = new ICAL.RecurExpansion({
+        component: vevent,
+        dtstart: event.startDate,
+      });
+      let occ;
+      while ((occ = expand.next())) {
+        if (occ.compare(targetRange.end) > 0) break;
+        if (occ.compare(targetRange.start) >= 0) {
+          dtstart = occ;
+          dtend = occ.clone();
+          dtend.addDuration(event.duration);
+          break;
+        }
+      }
+    }
+
     return {
       summary: event.summary || '',
       description: event.description || '',
       location: event.location || '',
       uid: event.uid || '',
-      dtstart: event.startDate,
-      dtend: event.endDate,
+      dtstart,
+      dtend,
       isRecurring: event.isRecurring(),
       rrule: event.isRecurring() ? vevent.getFirstPropertyValue('rrule') : null,
       organizer: vevent.getFirstPropertyValue('organizer'),
@@ -143,19 +168,24 @@ function formatDateTime(icalTime) {
   try {
     // Convert ICAL.Time to JavaScript Date
     const jsDate = icalTime.toJSDate();
+    // ical.js v2 stores timezone as icalTime.zone.tzid (an ICAL.Timezone object),
+    // not as the deprecated icalTime.timezone string property.
+    // Fall back to UTC for floating times or if no zone is set.
+    const tzid = icalTime.zone?.tzid;
+    const tz = (tzid && tzid !== 'floating') ? tzid : 'UTC';
 
     const dateStr = jsDate.toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'long',
       day: 'numeric',
-      timeZone: icalTime.timezone === 'UTC' ? 'UTC' : undefined,
+      timeZone: tz,
     });
 
     const timeStr = jsDate.toLocaleTimeString('en-US', {
       hour: '2-digit',
       minute: '2-digit',
       timeZoneName: 'short',
-      timeZone: icalTime.timezone === 'UTC' ? 'UTC' : undefined,
+      timeZone: tz,
     });
 
     return `${dateStr}, ${timeStr}`;
@@ -168,8 +198,12 @@ function formatDateTime(icalTime) {
 /**
  * Format a single calendar event to Markdown
  */
-export function formatEvent(event, calendarName = 'Unknown Calendar') {
-  const parsed = parseICalEvent(event.data);
+export function formatEvent(event, calendarName = 'Unknown Calendar', timeRange = null) {
+  const targetRange = timeRange ? {
+    start: ICAL.Time.fromDateTimeString(timeRange.start),
+    end: ICAL.Time.fromDateTimeString(timeRange.end),
+  } : null;
+  const parsed = parseICalEvent(event.data, targetRange);
 
   const startDate = formatDateTime(parsed.dtstart);
   const endDate = formatDateTime(parsed.dtend);
@@ -229,7 +263,7 @@ export function formatEvent(event, calendarName = 'Unknown Calendar') {
 /**
  * Format a list of calendar events to LLM-friendly Markdown
  */
-export function formatEventList(events, calendarName = 'Unknown Calendar') {
+export function formatEventList(events, calendarName = 'Unknown Calendar', timeRange = null) {
   if (!events || events.length === 0) {
     return {
       content: [{
@@ -243,7 +277,7 @@ export function formatEventList(events, calendarName = 'Unknown Calendar') {
 
   events.forEach((event, index) => {
     output += `### ${index + 1}. `;
-    output += formatEvent(event, calendarName).replace(/^## /, '') + '\n';
+    output += formatEvent(event, calendarName, timeRange).replace(/^## /, '') + '\n';
   });
 
   output += `---\n<details>\n<summary>Raw Data (JSON)</summary>\n\n\`\`\`json\n`;

--- a/src/formatters.js
+++ b/src/formatters.js
@@ -13,11 +13,6 @@ import ICAL from 'ical.js';
 
 /**
  * Parse iCal data string to extract event properties (RFC 5545 compliant)
- *
- * @param {string} icalData - Raw iCalendar text
- * @param {{ start: ICAL.Time, end: ICAL.Time } | null} targetRange - When provided and the
- *   event is recurring, expands the RRULE to find the first occurrence within the range so
- *   the displayed "When" reflects the actual queried occurrence rather than the master DTSTART.
  */
 function parseICalEvent(icalData, targetRange = null) {
   try {
@@ -168,9 +163,7 @@ function formatDateTime(icalTime) {
   try {
     // Convert ICAL.Time to JavaScript Date
     const jsDate = icalTime.toJSDate();
-    // ical.js v2 stores timezone as icalTime.zone.tzid (an ICAL.Timezone object),
-    // not as the deprecated icalTime.timezone string property.
-    // Fall back to UTC for floating times or if no zone is set.
+    // ical.js v2: timezone lives in zone.tzid, not the deprecated timezone property.
     const tzid = icalTime.zone?.tzid;
     const tz = (tzid && tzid !== 'floating') ? tzid : 'UTC';
 

--- a/src/tools/calendar/calendar-query.js
+++ b/src/tools/calendar/calendar-query.js
@@ -93,6 +93,11 @@ export const calendarQuery = {
       ? (calendarsToSearch[0].displayName || calendarsToSearch[0].url)
       : `All Calendars (${calendarsToSearch.length})`;
 
-    return formatEventList(filteredEvents, calendarName);
+    const timeRange = validated.time_range_start ? {
+      start: validated.time_range_start,
+      end: validated.time_range_end,
+    } : null;
+
+    return formatEventList(filteredEvents, calendarName, timeRange);
   },
 };

--- a/src/tools/calendar/list-events.js
+++ b/src/tools/calendar/list-events.js
@@ -38,6 +38,11 @@ export const listEvents = {
 
     const events = await client.fetchCalendarObjects(options);
 
-    return formatEventList(events, calendar);
+    const timeRange = validated.time_range_start ? {
+      start: validated.time_range_start,
+      end: validated.time_range_end,
+    } : null;
+
+    return formatEventList(events, calendar, timeRange);
   },
 };


### PR DESCRIPTION
## Problem

When \`calendar_query\` or \`list_events\` is called with a time range, the CalDAV
server returns the master VEVENT for recurring events rather than expanding
occurrences. This caused two bugs:

1. **Wrong date** — "When" always showed the master DTSTART (e.g. January 21)
   even for an April query. The LLM had to mentally expand the RRULE with no
   visual cue.

2. **Wrong UTC offset across DST** — January master is EST (UTC-5), so 6 AM
   EST = 11 AM UTC. An April occurrence is EDT (UTC-4), so 6 AM EDT = 10 AM
   UTC. The displayed time was off by 1 hour across DST boundaries.

There was also a secondary bug: \`formatDateTime\` used \`icalTime.timezone\` which
is \`undefined\` in ical.js v2; the correct property is \`icalTime.zone.tzid\`.

## Fix

- \`parseICalEvent\` accepts an optional \`targetRange\` and uses
  \`ICAL.RecurExpansion\` to find the first occurrence within the range.
- \`formatDateTime\` uses \`icalTime.zone.tzid\` for display timezone.
- \`calendar_query\` and \`list_events\` thread the time range through to the
  formatter.

## Note for maintainer

This PR overlaps with the files in #39 (different lines — all-day vs DST fix).
Merging this one first lets #39 rebase cleanly on top without duplicating these
commits.