### PR TITLE
fix: replace non-existent todo methods with real tsdav CalendarObject API

### DIFF
--- a/src/tools/todos/create-todo.js
+++ b/src/tools/todos/create-todo.js
@@ -86,7 +86,7 @@ export const createTodo = {
     vtodo += 'END:VTODO\r\n';
     vtodo += 'END:VCALENDAR\r\n';
 
-    const result = await client.createTodo({
+    const result = await client.createCalendarObject({
       calendar: { url: validated.calendar_url },
       filename: `${Date.now()}.ics`,
       iCalString: vtodo,

--- a/src/tools/todos/delete-todo.js
+++ b/src/tools/todos/delete-todo.js
@@ -26,7 +26,7 @@ export const deleteTodo = {
     const validated = validateInput(deleteTodoSchema, args);
     const client = tsdavManager.getCalDavClient();
 
-    await client.deleteTodo({
+    await client.deleteCalendarObject({
       calendarObject: {
         url: validated.todo_url,
         etag: validated.todo_etag,

--- a/src/tools/todos/list-todos.js
+++ b/src/tools/todos/list-todos.js
@@ -23,7 +23,10 @@ export const listTodos = {
     const client = tsdavManager.getCalDavClient();
 
     const calendar = { url: validated.calendar_url };
-    const todos = await client.fetchTodos({ calendar });
+    const todos = await client.fetchCalendarObjects({
+      calendar,
+      filters: [{ 'comp-filter': { _attributes: { name: 'VCALENDAR' }, 'comp-filter': { _attributes: { name: 'VTODO' } } } }],
+    });
 
     return formatTodoList(todos, validated.calendar_url);
   },

--- a/src/tools/todos/todo-query.js
+++ b/src/tools/todos/todo-query.js
@@ -58,7 +58,10 @@ export const todoQuery = {
     // Fetch todos from all selected calendars
     let todos = [];
     for (const calendar of calendarsToSearch) {
-      const calendarTodos = await client.fetchTodos({ calendar });
+      const calendarTodos = await client.fetchCalendarObjects({
+        calendar,
+        filters: [{ 'comp-filter': { _attributes: { name: 'VCALENDAR' }, 'comp-filter': { _attributes: { name: 'VTODO' } } } }],
+      });
       // Add calendar info to each todo
       calendarTodos.forEach(todo => {
         todo._calendarName = calendar.displayName || calendar.url;
@@ -66,7 +69,7 @@ export const todoQuery = {
       todos = todos.concat(calendarTodos);
     }
 
-    // Client-side filtering (tsdav doesn't support server-side VTODO filtering yet)
+    // Client-side filtering applied after server returns VTODO objects
     if (validated.summary_filter) {
       const summaryLower = validated.summary_filter.toLowerCase();
       todos = todos.filter(todo => {

--- a/src/tools/todos/update-todo-fields.js
+++ b/src/tools/todos/update-todo-fields.js
@@ -81,9 +81,10 @@ export const updateTodoFields = {
 
     // Step 1: Fetch the current todo from server
     const calendarUrl = validated.todo_url.substring(0, validated.todo_url.lastIndexOf('/') + 1);
-    const currentTodos = await client.fetchTodos({
+    const currentTodos = await client.fetchCalendarObjects({
       calendar: { url: calendarUrl },
-      objectUrls: [validated.todo_url]
+      objectUrls: [validated.todo_url],
+      filters: [{ 'comp-filter': { _attributes: { name: 'VCALENDAR' }, 'comp-filter': { _attributes: { name: 'VTODO' } } } }],
     });
 
     if (!currentTodos || currentTodos.length === 0) {
@@ -97,7 +98,7 @@ export const updateTodoFields = {
     const updatedData = updateFields(todoObject, validated.fields || {});
 
     // Step 3: Send the updated todo back to server
-    const updateResponse = await client.updateTodo({
+    const updateResponse = await client.updateCalendarObject({
       calendarObject: {
         url: validated.todo_url,
         data: updatedData,

--- a/src/tools/todos/update-todo-raw.js
+++ b/src/tools/todos/update-todo-raw.js
@@ -30,7 +30,7 @@ export const updateTodoRaw = {
     const validated = validateInput(updateTodoSchema, args);
     const client = tsdavManager.getCalDavClient();
 
-    const result = await client.updateTodo({
+    const result = await client.updateCalendarObject({
       calendarObject: {
         url: validated.todo_url,
         data: validated.updated_ical_data,


### PR DESCRIPTION
## Problem

All six VTODO tools fail at runtime because they call methods that don't exist on `DAVClient` from the PhilflowIO tsdav fork:

- `client.fetchTodos()` → `TypeError: client.fetchTodos is not a function`
- `client.createTodo()` → same
- `client.deleteTodo()` → same
- `client.updateTodo()` → same

The tsdav fork only exposes the generic `fetchCalendarObjects`, `createCalendarObject`, `updateCalendarObject`, and `deleteCalendarObject` on `DAVClient`. The VTODO-specific wrappers were never added.

## Fix

Replace each non-existent method with the correct tsdav API call:

| Before | After |
|--------|-------|
| `client.fetchTodos({ calendar })` | `client.fetchCalendarObjects({ calendar, filters: [VTODO comp-filter] })` |
| `client.fetchTodos({ calendar, objectUrls })` | `client.fetchCalendarObjects({ calendar, objectUrls, filters: [VTODO comp-filter] })` |
| `client.createTodo({ calendar, ... })` | `client.createCalendarObject({ calendar, ... })` |
| `client.deleteTodo({ calendarObject })` | `client.deleteCalendarObject({ calendarObject })` |
| `client.updateTodo({ calendarObject })` | `client.updateCalendarObject({ calendarObject })` |

The `comp-filter` for VTODO instructs the CalDAV server to return only VTODO objects (tasks), not VEVENTs or other component types. This replaces the previously intended client-side-only approach.

Note: the `calendarObject:` parameter rename (instead of `todo:`) was already fixed in #37 — this PR only corrects the method names.

## Files changed

- `src/tools/todos/list-todos.js`
- `src/tools/todos/todo-query.js`
- `src/tools/todos/create-todo.js`
- `src/tools/todos/delete-todo.js`
- `src/tools/todos/update-todo-raw.js`
- `src/tools/todos/update-todo-fields.js`