### PR TITLE
fix: harden iCal/vCard input handling in the update and create tools

### DIFF
--- a/__tests__/dav-field-map.test.js
+++ b/__tests__/dav-field-map.test.js
@@ -1,0 +1,102 @@
+import { describe, test, expect } from '@jest/globals';
+import { z } from 'zod';
+import ICAL from 'ical.js';
+import { updateFields } from 'tsdav-utils';
+import { davFieldMapSchema, validateInput } from '../src/validation.js';
+
+const schema = z.object({ fields: davFieldMapSchema });
+const parse = (fields) => validateInput(schema, { fields });
+
+const VEVENT = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+UID:field-map@example.com
+DTSTAMP:20260101T000000Z
+DTSTART:20260525T100000Z
+DTEND:20260525T110000Z
+SUMMARY:Original
+END:VEVENT
+END:VCALENDAR`;
+
+describe('davFieldMapSchema', () => {
+  test('accepts bare property names', () => {
+    expect(parse({ SUMMARY: 'New title', LOCATION: 'Room 1' }).fields)
+      .toEqual({ SUMMARY: 'New title', LOCATION: 'Room 1' });
+  });
+
+  test('accepts custom X-* properties', () => {
+    expect(parse({ 'X-ZOOM-LINK': 'https://example.com/j/1' }).fields)
+      .toEqual({ 'X-ZOOM-LINK': 'https://example.com/j/1' });
+  });
+
+  test('is optional', () => {
+    expect(validateInput(schema, {}).fields).toBeUndefined();
+  });
+
+  test('rejects a key containing a colon', () => {
+    expect(() => parse({ 'SUMMARY:X\r\nDESCRIPTION': 'v' }))
+      .toThrow(/is not a bare property name/);
+  });
+
+  test('rejects a key containing a line break', () => {
+    expect(() => parse({ 'X-A\r\nDESCRIPTION': 'v' }))
+      .toThrow(/is not a bare property name/);
+  });
+
+  test('rejects a key carrying a property parameter', () => {
+    // updatePropertyWithValue keys on the property name alone, so this would
+    // append a second DTSTART rather than replace the existing one.
+    expect(() => parse({ 'DTSTART;VALUE=DATE': '20260525' }))
+      .toThrow(/parameters such as ";VALUE=DATE" are not supported/);
+  });
+
+  test('rejects a value containing a newline', () => {
+    expect(() => parse({ 'X-NOTE': 'hi\nDESCRIPTION:injected' }))
+      .toThrow(/must not contain line breaks/);
+  });
+
+  test('rejects a value containing a bare carriage return', () => {
+    expect(() => parse({ 'X-NOTE': 'hi\rDESCRIPTION:injected' }))
+      .toThrow(/must not contain line breaks/);
+  });
+
+  test('names the offending field in the error', () => {
+    expect(() => parse({ SUMMARY: 'fine', 'X-BAD': 'a\nb' }))
+      .toThrow(/X-BAD/);
+  });
+});
+
+describe('injection payloads no longer reach updateFields', () => {
+  const emit = (fields) => updateFields({ data: VEVENT }, parse(fields).fields);
+
+  test('accepted fields still update the event', () => {
+    const out = emit({ SUMMARY: 'New title', STATUS: 'CANCELLED' });
+    const vevent = new ICAL.Component(ICAL.parse(out)).getFirstSubcomponent('vevent');
+    expect(vevent.getFirstPropertyValue('summary')).toBe('New title');
+    expect(vevent.getFirstPropertyValue('status')).toBe('CANCELLED');
+    expect(vevent.getAllProperties('summary')).toHaveLength(1);
+  });
+
+  test('a second VEVENT cannot be injected through a value', () => {
+    expect(() => emit({
+      'X-NOTE': 'hi\nEND:VEVENT\nBEGIN:VEVENT\nUID:evil@example.com\nSUMMARY:Ghost',
+    })).toThrow(/must not contain line breaks/);
+  });
+
+  test('a VALARM cannot be attached through a value', () => {
+    expect(() => emit({
+      'X-NOTE': 'v\nBEGIN:VALARM\nACTION:EMAIL\nATTENDEE:mailto:attacker@example.com\nTRIGGER:-PT15M\nEND:VALARM',
+    })).toThrow(/must not contain line breaks/);
+  });
+
+  test('a property cannot be injected through a key', () => {
+    expect(() => emit({ 'X-A\r\nDESCRIPTION:injected\r\nX-B': 'v' }))
+      .toThrow(/is not a bare property name/);
+  });
+
+  test('a parameterised key cannot produce a duplicate DTSTART', () => {
+    expect(() => emit({ 'DTSTART;VALUE=DATE': '20260525' }))
+      .toThrow(/not a bare property name/);
+  });
+});

--- a/__tests__/line-endings.test.js
+++ b/__tests__/line-endings.test.js
@@ -1,0 +1,130 @@
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+
+// The create tools build their document by hand, so the only way to assert the
+// emitted bytes is to drive the handler with a stubbed DAV client.
+const CALENDAR_URL = 'https://dav.example.com/calendars/user/work/';
+const ADDRESSBOOK_URL = 'https://dav.example.com/addressbooks/user/default/';
+
+const createCalendarObject = jest.fn(async () => ({ url: `${CALENDAR_URL}e.ics`, etag: '"1"' }));
+const createVCard = jest.fn(async () => ({ url: `${ADDRESSBOOK_URL}c.vcf`, etag: '"1"' }));
+const createTodoObject = jest.fn(async () => ({ url: `${CALENDAR_URL}t.ics`, etag: '"1"' }));
+
+jest.unstable_mockModule('../src/tsdav-client.js', () => ({
+  tsdavManager: {
+    getCalDavClient: () => ({
+      fetchCalendars: async () => [{ url: CALENDAR_URL, displayName: 'Work' }],
+      createCalendarObject,
+      createTodo: createTodoObject,
+    }),
+    getCardDavClient: () => ({
+      fetchAddressBooks: async () => [{ url: ADDRESSBOOK_URL, displayName: 'Default' }],
+      createVCard,
+    }),
+  },
+}));
+
+const { createEvent } = await import('../src/tools/calendar/create-event.js');
+const { createContact } = await import('../src/tools/contacts/create-contact.js');
+const { createTodo } = await import('../src/tools/todos/create-todo.js');
+
+const assertCrlfOnly = (document) => {
+  expect(document).toContain('\r\n');
+  // every LF must be preceded by a CR, and no CR may stand alone
+  expect(document).not.toMatch(/(^|[^\r])\n/);
+  expect(document).not.toMatch(/\r(?!\n)/);
+};
+
+beforeEach(() => {
+  createCalendarObject.mockClear();
+  createVCard.mockClear();
+  createTodoObject.mockClear();
+});
+
+describe('emitted documents use CRLF line endings', () => {
+  test('create_event', async () => {
+    await createEvent.handler({
+      calendar_url: CALENDAR_URL,
+      summary: 'Standup',
+      start_date: '2026-05-25T10:00:00Z',
+      end_date: '2026-05-25T11:00:00Z',
+      description: 'Daily sync',
+      location: 'Room 1',
+    });
+
+    const { iCalString } = createCalendarObject.mock.calls[0][0];
+    assertCrlfOnly(iCalString);
+    expect(iCalString).toContain('SUMMARY:Standup');
+    expect(iCalString).toContain('DESCRIPTION:Daily sync');
+    expect(iCalString).toContain('LOCATION:Room 1');
+  });
+
+  test('create_event omits optional properties it was not given', async () => {
+    await createEvent.handler({
+      calendar_url: CALENDAR_URL,
+      summary: 'Standup',
+      start_date: '2026-05-25T10:00:00Z',
+      end_date: '2026-05-25T11:00:00Z',
+    });
+
+    const { iCalString } = createCalendarObject.mock.calls[0][0];
+    assertCrlfOnly(iCalString);
+    expect(iCalString).not.toContain('DESCRIPTION:');
+    expect(iCalString).not.toContain('LOCATION:');
+  });
+
+  test('create_contact', async () => {
+    await createContact.handler({
+      addressbook_url: ADDRESSBOOK_URL,
+      full_name: 'Ada Lovelace',
+      given_name: 'Ada',
+      family_name: 'Lovelace',
+      email: 'ada@example.com',
+      phone: '+49 30 1234',
+      organization: 'Analytical Engines',
+      note: 'First programmer',
+    });
+
+    const { vCardString } = createVCard.mock.calls[0][0];
+    assertCrlfOnly(vCardString);
+    expect(vCardString).toContain('FN:Ada Lovelace');
+    expect(vCardString).toContain('EMAIL;TYPE=INTERNET:ada@example.com');
+  });
+
+  test('create_todo (already correct, guarded against regression)', async () => {
+    await createTodo.handler({
+      calendar_url: CALENDAR_URL,
+      summary: 'Write the report',
+    });
+
+    const { iCalString } = createTodoObject.mock.calls[0][0];
+    assertCrlfOnly(iCalString.replace(/\r\n$/, ''));
+  });
+});
+
+describe('hostile input cannot open a new content line', () => {
+  test('create_event escapes line breaks in the summary', async () => {
+    await createEvent.handler({
+      calendar_url: CALENDAR_URL,
+      summary: 'Standup\r\nSUMMARY:HIJACKED',
+      start_date: '2026-05-25T10:00:00Z',
+      end_date: '2026-05-25T11:00:00Z',
+    });
+
+    const { iCalString } = createCalendarObject.mock.calls[0][0];
+    assertCrlfOnly(iCalString);
+    expect(iCalString).toContain('SUMMARY:Standup\\nSUMMARY:HIJACKED');
+    expect(iCalString.match(/^SUMMARY:/gm)).toHaveLength(1);
+  });
+
+  test('create_contact escapes line breaks in the note', async () => {
+    await createContact.handler({
+      addressbook_url: ADDRESSBOOK_URL,
+      full_name: 'Ada Lovelace',
+      note: 'ok\rNOTE:injected',
+    });
+
+    const { vCardString } = createVCard.mock.calls[0][0];
+    assertCrlfOnly(vCardString);
+    expect(vCardString.match(/^NOTE:/gm)).toHaveLength(1);
+  });
+});

--- a/__tests__/validation.test.js
+++ b/__tests__/validation.test.js
@@ -32,6 +32,19 @@ describe('Validation Module', () => {
       expect(result).toBe('test\\nstring');
     });
 
+    test('should escape CRLF as a single newline', () => {
+      expect(sanitizeICalString('test\r\nstring')).toBe('test\\nstring');
+    });
+
+    test('should escape a bare carriage return', () => {
+      expect(sanitizeICalString('test\rstring')).toBe('test\\nstring');
+    });
+
+    test('should leave no raw control characters behind', () => {
+      const result = sanitizeICalString('a\r\nSUMMARY:injected\rX-EVIL:1');
+      expect(result).not.toMatch(/[\r\n]/);
+    });
+
     test('should handle empty string', () => {
       const result = sanitizeICalString('');
       expect(result).toBe('');

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/philflow/Dokumente/coding/dav-mcp/dav-mcp-src/node_modules

--- a/src/tools/calendar/create-event.js
+++ b/src/tools/calendar/create-event.js
@@ -52,17 +52,22 @@ export const createEvent = {
     const description = validated.description ? sanitizeICalString(validated.description) : '';
     const location = validated.location ? sanitizeICalString(validated.location) : '';
 
-    const iCalString = `BEGIN:VCALENDAR
-VERSION:2.0
-PRODID:-//tsdav-mcp-server//EN
-BEGIN:VEVENT
-UID:${uid}
-DTSTAMP:${formatICalDate(now)}
-DTSTART:${formatICalDate(new Date(validated.start_date))}
-DTEND:${formatICalDate(new Date(validated.end_date))}
-SUMMARY:${summary}${description ? `\nDESCRIPTION:${description}` : ''}${location ? `\nLOCATION:${location}` : ''}
-END:VEVENT
-END:VCALENDAR`;
+    // RFC 5545 3.1: content lines are delimited by CRLF, not LF
+    const iCalString = [
+      'BEGIN:VCALENDAR',
+      'VERSION:2.0',
+      'PRODID:-//tsdav-mcp-server//EN',
+      'BEGIN:VEVENT',
+      `UID:${uid}`,
+      `DTSTAMP:${formatICalDate(now)}`,
+      `DTSTART:${formatICalDate(new Date(validated.start_date))}`,
+      `DTEND:${formatICalDate(new Date(validated.end_date))}`,
+      `SUMMARY:${summary}`,
+      description ? `DESCRIPTION:${description}` : null,
+      location ? `LOCATION:${location}` : null,
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].filter(Boolean).join('\r\n');
 
     const response = await client.createCalendarObject({
       calendar,

--- a/src/tools/calendar/update-event-fields.js
+++ b/src/tools/calendar/update-event-fields.js
@@ -1,5 +1,5 @@
 import { tsdavManager } from '../../tsdav-client.js';
-import { validateInput } from '../../validation.js';
+import { validateInput, davFieldMapSchema } from '../../validation.js';
 import { formatSuccess } from '../../formatters.js';
 import { z } from 'zod';
 import { updateFields } from 'tsdav-utils';
@@ -7,18 +7,20 @@ import { updateFields } from 'tsdav-utils';
 /**
  * Schema for field-based event updates
  * Supports all RFC 5545 iCalendar properties via tsdav-utils
+ * Field names are validated as bare property names; see davFieldMapSchema
  * Common fields: SUMMARY, DESCRIPTION, LOCATION, DTSTART, DTEND, STATUS
  * Custom properties: Any X-* property
  */
 const updateEventFieldsSchema = z.object({
   event_url: z.string().url('Event URL must be a valid URL'),
   event_etag: z.string().min(1, 'Event etag is required'),
-  fields: z.record(z.string()).optional()
+  fields: davFieldMapSchema
 });
 
 /**
  * Field-agnostic event update tool powered by tsdav-utils
- * Supports all RFC 5545 iCalendar properties without validation
+ * Supports any bare RFC 5545 property name; parameters and multi-line
+ * values are rejected by the schema
  *
  * Features:
  * - Any standard VEVENT property (SUMMARY, DESCRIPTION, LOCATION, DTSTART, etc.)
@@ -41,7 +43,7 @@ export const updateEventFields = {
       },
       fields: {
         type: 'object',
-        description: 'Fields to update - use UPPERCASE property names (e.g., SUMMARY, LOCATION, DTSTART). Any RFC 5545 property or custom X-* property is supported.',
+        description: 'Fields to update, keyed by bare UPPERCASE property name (e.g., SUMMARY, LOCATION, DTSTART). Any RFC 5545 property or custom X-* property is supported. Property parameters such as "DTSTART;VALUE=DATE" are not accepted here, and values must not contain line breaks.',
         additionalProperties: {
           type: 'string'
         },

--- a/src/tools/contacts/create-contact.js
+++ b/src/tools/contacts/create-contact.js
@@ -62,12 +62,20 @@ export const createContact = {
     const organization = validated.organization ? sanitizeVCardString(validated.organization) : '';
     const note = validated.note ? sanitizeVCardString(validated.note) : '';
 
-    const vCardString = `BEGIN:VCARD
-VERSION:3.0
-UID:${uid}
-FN:${fullName}${familyName || givenName ? `\nN:${familyName};${givenName};;;` : ''}${email ? `\nEMAIL;TYPE=INTERNET:${email}` : ''}${phone ? `\nTEL;TYPE=CELL:${phone}` : ''}${organization ? `\nORG:${organization}` : ''}${note ? `\nNOTE:${note}` : ''}
-REV:${new Date().toISOString()}
-END:VCARD`;
+    // RFC 6350 3.2: content lines are delimited by CRLF, not LF
+    const vCardString = [
+      'BEGIN:VCARD',
+      'VERSION:3.0',
+      `UID:${uid}`,
+      `FN:${fullName}`,
+      familyName || givenName ? `N:${familyName};${givenName};;;` : null,
+      email ? `EMAIL;TYPE=INTERNET:${email}` : null,
+      phone ? `TEL;TYPE=CELL:${phone}` : null,
+      organization ? `ORG:${organization}` : null,
+      note ? `NOTE:${note}` : null,
+      `REV:${new Date().toISOString()}`,
+      'END:VCARD',
+    ].filter(Boolean).join('\r\n');
 
     const response = await client.createVCard({
       addressBook,

--- a/src/tools/contacts/update-contact-fields.js
+++ b/src/tools/contacts/update-contact-fields.js
@@ -1,5 +1,5 @@
 import { tsdavManager } from '../../tsdav-client.js';
-import { validateInput } from '../../validation.js';
+import { validateInput, davFieldMapSchema } from '../../validation.js';
 import { formatSuccess } from '../../formatters.js';
 import { z } from 'zod';
 import { updateFields } from 'tsdav-utils';
@@ -13,7 +13,7 @@ import { updateFields } from 'tsdav-utils';
 const updateContactFieldsSchema = z.object({
   vcard_url: z.string().url('vCard URL must be a valid URL'),
   vcard_etag: z.string().min(1, 'vCard etag is required'),
-  fields: z.record(z.string()).optional()
+  fields: davFieldMapSchema
 });
 
 /**
@@ -41,7 +41,7 @@ export const updateContactFields = {
       },
       fields: {
         type: 'object',
-        description: 'Fields to update - use UPPERCASE property names (e.g., FN, EMAIL, TEL). Any RFC 6350 vCard property or custom X-* property is supported.',
+        description: 'Fields to update, keyed by bare UPPERCASE property name (e.g., FN, EMAIL, TEL). Any RFC 6350 vCard property or custom X-* property is supported. Property parameters such as "TEL;TYPE=CELL" are not accepted here, and values must not contain line breaks.',
         additionalProperties: {
           type: 'string'
         },

--- a/src/tools/todos/update-todo-fields.js
+++ b/src/tools/todos/update-todo-fields.js
@@ -1,5 +1,5 @@
 import { tsdavManager } from '../../tsdav-client.js';
-import { validateInput } from '../../validation.js';
+import { validateInput, davFieldMapSchema } from '../../validation.js';
 import { formatSuccess } from '../../formatters.js';
 import { z } from 'zod';
 import { updateFields } from 'tsdav-utils';
@@ -13,7 +13,7 @@ import { updateFields } from 'tsdav-utils';
 const updateTodoFieldsSchema = z.object({
   todo_url: z.string().url('Todo URL must be a valid URL'),
   todo_etag: z.string().min(1, 'Todo etag is required'),
-  fields: z.record(z.string()).optional()
+  fields: davFieldMapSchema
 });
 
 /**
@@ -41,7 +41,7 @@ export const updateTodoFields = {
       },
       fields: {
         type: 'object',
-        description: 'Fields to update - use UPPERCASE property names (e.g., SUMMARY, STATUS, PRIORITY). Any RFC 5545 VTODO property or custom X-* property is supported.',
+        description: 'Fields to update, keyed by bare UPPERCASE property name (e.g., SUMMARY, STATUS, PRIORITY). Any RFC 5545 VTODO property or custom X-* property is supported. Property parameters such as "DUE;VALUE=DATE" are not accepted here, and values must not contain line breaks.',
         additionalProperties: {
           type: 'string'
         },

--- a/src/validation.js
+++ b/src/validation.js
@@ -11,6 +11,39 @@ const dateTimeWithOptionalOffset = z.union([
   z.string().regex(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/, 'Invalid datetime format') // Without timezone
 ]);
 
+// Helper: field map for the field-based update tools (update_event/_todo/_contact)
+//
+// Both halves of this check are load-bearing. tsdav-utils' updateFields calls
+// updatePropertyWithValue(key.toLowerCase(), value), which keys on the property
+// NAME alone:
+//   - a key carrying a parameter ("DTSTART;VALUE=DATE") does not replace
+//     DTSTART, it appends a second one (RFC 5545 3.6.1: MUST NOT occur twice)
+//   - a key carrying ":" or a line break injects further properties outright
+//   - ical.js escapes line breaks for known TEXT properties, but writes X-* and
+//     non-TEXT values verbatim, so values must stay on one line too
+const DAV_PROPERTY_NAME = /^[A-Za-z][A-Za-z0-9-]*$/;
+
+export const davFieldMapSchema = z.record(z.string(), z.string())
+  .superRefine((fields, ctx) => {
+    for (const [key, value] of Object.entries(fields)) {
+      if (!DAV_PROPERTY_NAME.test(key)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: `"${key}" is not a bare property name. Use letters, digits and "-" only (e.g. SUMMARY, X-ZOOM-LINK); parameters such as ";VALUE=DATE" are not supported here`,
+        });
+      }
+      if (/[\r\n]/.test(value)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: `value for "${key}" must not contain line breaks`,
+        });
+      }
+    }
+  })
+  .optional();
+
 // Helper: Optional URL that gracefully handles LLM placeholder values
 // Transforms common LLM-generated placeholders ("", "unknown", "default", etc.) to undefined
 const optionalUrl = (message) =>

--- a/src/validation.js
+++ b/src/validation.js
@@ -264,10 +264,11 @@ export function validateInput(schema, data) {
 export function sanitizeICalString(str) {
   if (!str) return '';
   return str
-    .replace(/\\/g, '\\\\')  // Escape backslashes
-    .replace(/;/g, '\\;')    // Escape semicolons
-    .replace(/,/g, '\\,')    // Escape commas
-    .replace(/\n/g, '\\n');  // Escape newlines
+    .replace(/\\/g, '\\\\')    // Escape backslashes
+    .replace(/;/g, '\\;')      // Escape semicolons
+    .replace(/,/g, '\\,')      // Escape commas
+    .replace(/\r\n?/g, '\\n')  // Escape CRLF and bare CR (before the LF rule,
+    .replace(/\n/g, '\\n');    // so that a CRLF collapses into one escape)
 }
 
 /**


### PR DESCRIPTION
Two related defects in how user-supplied text reaches the DAV server, found while reviewing #39/#40.

## `fields` map allowed property and component injection (#44)

`update_event`, `update_todo` and `update_contact` typed their `fields` map as `z.record(z.string())` — no constraint on key or value — and `tsdav-utils` hands each entry to `updatePropertyWithValue(key.toLowerCase(), value)`, which keys on the property *name* alone. Verified by re-parsing the emitted document: a value could terminate the VEVENT and open a second, fully caller-shaped one; a key containing `:` or a line break injected properties outright; a `VALARM` with `ACTION:EMAIL` and an arbitrary ATTENDEE could be attached.

Both halves of the new check are load-bearing — ical.js escapes line breaks for known TEXT properties but writes `X-*` and non-TEXT values verbatim, so constraining only keys or only values leaves half the door open.

Restricting keys to bare property names fixes a second bug in passing: `DTSTART;VALUE=DATE` was treated as a property *name*, so it appended a duplicate DTSTART instead of replacing the existing one (RFC 5545 §3.6.1: MUST NOT occur twice).

The `create_*` tools were never affected — they route through `sanitizeICalString`. The `*_raw` tools stay unvalidated, which is their documented purpose.

## Documents were emitted with LF line endings (#47)

`sanitizeICalString` escaped LF but let a bare CR through, and `create_event` / `create_contact` joined content lines with LF where RFC 5545 §3.1 and RFC 6350 §3.2 require CRLF. `create_todo` already did this correctly and is now covered by a regression test.

## Tests

99 passing, up from 76. Two new files: `__tests__/dav-field-map.test.js` (schema plus the injection payloads driven through the real `updateFields`) and `__tests__/line-endings.test.js`, which drives the create handlers against a stubbed DAV client — that mocking setup is reusable for the remaining fixes.

Closes #44
Closes #47