### PR TITLE
chore: untrack the accidental node_modules symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Node
 node_modules/
+node_modules
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/philflow/Dokumente/coding/dav-mcp/dav-mcp-src/node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dav-mcp",
-  "version": "3.0.1",
+  "version": "3.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dav-mcp",
-      "version": "3.0.1",
+      "version": "3.0.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.3",


### PR DESCRIPTION
Repairs a mistake in #49 and closes the hole that allowed it.

`1f27d02` committed a `node_modules` **symlink** pointing at an absolute path on my machine. `.gitignore` carried `node_modules/`, which matches a directory but not a symlink of the same name, so `git add -A` picked it up unnoticed. Checking the branch out afterwards replaced a real dependency tree with a link pointing at itself (`ELOOP` on every `require`), which is how it was caught.

- untrack the symlink
- ignore the bare name alongside the directory rule, so both hold
- sync `package-lock.json` to 3.0.7 (it still said 3.0.1; npm rewrites those two lines on any install)

Tests: 99 passing.