### PR TITLE
fix: surface silent failures in deletes and tool-call logging

### DIFF
--- a/__tests__/delete-failures.test.js
+++ b/__tests__/delete-failures.test.js
@@ -1,0 +1,91 @@
+import { describe, test, expect, beforeEach, afterEach, jest } from '@jest/globals';
+
+const CALENDAR_URL = 'https://dav.example.com/calendars/user/work/';
+const EVENT_URL = `${CALENDAR_URL}e.ics`;
+
+const deleteObject = jest.fn();
+const deleteCalendarObject = jest.fn();
+const deleteVCard = jest.fn();
+const deleteTodo = jest.fn();
+
+jest.unstable_mockModule('../src/tsdav-client.js', () => ({
+  tsdavManager: {
+    getCalDavClient: () => ({ deleteObject, deleteCalendarObject, deleteTodo }),
+    getCardDavClient: () => ({ deleteVCard }),
+  },
+}));
+
+const { deleteCalendar } = await import('../src/tools/calendar/delete-calendar.js');
+const { deleteEvent } = await import('../src/tools/calendar/delete-event.js');
+const { deleteContact } = await import('../src/tools/contacts/delete-contact.js');
+const { deleteTodo: deleteTodoTool } = await import('../src/tools/todos/delete-todo.js');
+
+const davResponse = (status, statusText = '', body = '') => ({
+  ok: status >= 200 && status < 300,
+  status,
+  statusText,
+  text: async () => body,
+});
+
+beforeEach(() => {
+  [deleteObject, deleteCalendarObject, deleteVCard, deleteTodo].forEach(m => m.mockReset());
+});
+
+describe('a refused delete is reported as a failure', () => {
+  test('delete_calendar throws on 403', async () => {
+    deleteObject.mockResolvedValue(davResponse(403, 'Forbidden'));
+    await expect(deleteCalendar.handler({ calendar_url: CALENDAR_URL }))
+      .rejects.toThrow(/403/);
+  });
+
+  test('the error says the object is still there', async () => {
+    deleteObject.mockResolvedValue(davResponse(405, 'Method Not Allowed'));
+    await expect(deleteCalendar.handler({ calendar_url: CALENDAR_URL }))
+      .rejects.toThrow(/still exists on the server/);
+  });
+
+  test('the server response body is surfaced', async () => {
+    deleteObject.mockResolvedValue(davResponse(403, 'Forbidden', 'collection is read-only'));
+    await expect(deleteCalendar.handler({ calendar_url: CALENDAR_URL }))
+      .rejects.toThrow(/collection is read-only/);
+  });
+
+  test('delete_event throws on 409', async () => {
+    deleteCalendarObject.mockResolvedValue(davResponse(409, 'Conflict'));
+    await expect(deleteEvent.handler({ event_url: EVENT_URL, event_etag: '"1"' }))
+      .rejects.toThrow(/409/);
+  });
+
+  test('delete_contact throws on 500', async () => {
+    deleteVCard.mockResolvedValue(davResponse(500, 'Internal Server Error'));
+    await expect(deleteContact.handler({
+      vcard_url: 'https://dav.example.com/addressbooks/user/default/c.vcf',
+      vcard_etag: '"1"',
+    })).rejects.toThrow(/500/);
+  });
+
+  test('delete_todo throws on 403', async () => {
+    deleteTodo.mockResolvedValue(davResponse(403, 'Forbidden'));
+    await expect(deleteTodoTool.handler({ todo_url: `${CALENDAR_URL}t.ics`, todo_etag: '"1"' }))
+      .rejects.toThrow(/403/);
+  });
+});
+
+describe('a successful delete still succeeds', () => {
+  test('204 No Content', async () => {
+    deleteObject.mockResolvedValue(davResponse(204, 'No Content'));
+    const result = await deleteCalendar.handler({ calendar_url: CALENDAR_URL });
+    expect(result.content[0].text).toContain('deleted');
+  });
+
+  test('404 counts as done — DELETE is idempotent', async () => {
+    deleteCalendarObject.mockResolvedValue(davResponse(404, 'Not Found'));
+    await expect(deleteEvent.handler({ event_url: EVENT_URL, event_etag: '"1"' }))
+      .resolves.toBeDefined();
+  });
+
+  test('a tsdav version that returns no Response is not treated as a failure', async () => {
+    deleteObject.mockResolvedValue(undefined);
+    await expect(deleteCalendar.handler({ calendar_url: CALENDAR_URL })).resolves.toBeDefined();
+  });
+});

--- a/__tests__/log-sink.test.js
+++ b/__tests__/log-sink.test.js
@@ -1,0 +1,42 @@
+import { describe, test, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { writeLogLine } from '../src/log-sink.js';
+
+describe('logging never writes to stdout under the stdio transport', () => {
+  let stdoutSpy;
+  let stderrSpy;
+  const previousTransport = process.env.MCP_TRANSPORT;
+
+  beforeEach(() => {
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    process.env.MCP_TRANSPORT = previousTransport;
+  });
+
+  test('stdio mode goes to stderr', () => {
+    process.env.MCP_TRANSPORT = 'stdio';
+    writeLogLine('{"type":"tool_call_start"}');
+    expect(stderrSpy).toHaveBeenCalled();
+    expect(stdoutSpy).not.toHaveBeenCalled();
+  });
+
+  test('other transports may use stdout', () => {
+    process.env.MCP_TRANSPORT = 'http';
+    writeLogLine('{"type":"tool_call_start"}');
+    // console.log writes through process.stdout
+    expect(stdoutSpy).toHaveBeenCalled();
+  });
+
+  test('the tool call logger honours it in console mode', async () => {
+    process.env.MCP_TRANSPORT = 'stdio';
+    const { initializeToolCallLogger } = await import('../src/tool-call-logger.js');
+    initializeToolCallLogger({ outputMode: 'console', enabled: true })
+      .logToolCallStart('list_calendars', {});
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(stderrSpy).toHaveBeenCalled();
+  });
+});

--- a/src/log-sink.js
+++ b/src/log-sink.js
@@ -1,0 +1,24 @@
+/**
+ * Where a log line may go without corrupting the protocol.
+ *
+ * Under the stdio transport, stdout carries JSON-RPC and nothing else, so a log
+ * line written there breaks the client's parser. Both loggers share this one
+ * decision so that neither can drift away from it.
+ */
+
+// Read per call rather than at module load: the transport is set from the
+// environment, and tests need to exercise both modes in one process.
+export function isStdioMode() {
+  return process.env.MCP_TRANSPORT === 'stdio';
+}
+
+/**
+ * Write one line to the safe sink for the current transport.
+ */
+export function writeLogLine(line) {
+  if (isStdioMode()) {
+    process.stderr.write(line + '\n');
+  } else {
+    console.log(line);
+  }
+}

--- a/src/logger.js
+++ b/src/logger.js
@@ -6,8 +6,7 @@
  * corrupting JSON-RPC messages on stdout.
  */
 
-// Detect STDIO transport mode - must write to stderr to preserve stdout for JSON-RPC
-const isStdioMode = process.env.MCP_TRANSPORT === 'stdio';
+import { writeLogLine } from './log-sink.js';
 
 // Cache environment check to avoid repeated env access (satisfies CodeQL)
 const isProduction = process.env.NODE_ENV === 'production';
@@ -58,10 +57,8 @@ class JSONLogger {
       }
     }
 
-    // Output function: stderr for STDIO mode, stdout for HTTP mode
-    const output = isStdioMode
-      ? (msg) => process.stderr.write(msg + '\n')
-      : (msg) => console.log(msg);
+    // stderr under stdio, stdout otherwise — see src/log-sink.js
+    const output = writeLogLine;
 
     // Pretty-print in development, single-line JSON in production
     if (!isProduction) {

--- a/src/tool-call-logger.js
+++ b/src/tool-call-logger.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { writeLogLine } from './log-sink.js';
 
 /**
  * Tool Call Logger - Logs all MCP tool calls to JSON Lines format
@@ -30,7 +31,8 @@ class ToolCallLogger {
     const line = JSON.stringify(entry) + '\n';
 
     if (this.outputMode === 'console' || this.outputMode === 'both') {
-      console.log(line.trim());
+      // never console.log here: under stdio that is the JSON-RPC channel
+      writeLogLine(line.trim());
     }
 
     if (this.outputMode === 'file' || this.outputMode === 'both') {

--- a/src/tools/calendar/delete-calendar.js
+++ b/src/tools/calendar/delete-calendar.js
@@ -1,6 +1,7 @@
 import { tsdavManager } from '../../tsdav-client.js';
 import { validateInput, deleteCalendarSchema } from '../../validation.js';
 import { formatCalendarDeleteSuccess } from '../../formatters.js';
+import { assertDeleted } from '../shared/helpers.js';
 
 /**
  * Permanently delete a calendar and all its events
@@ -22,15 +23,14 @@ export const deleteCalendar = {
     const validated = validateInput(deleteCalendarSchema, args);
     const client = tsdavManager.getCalDavClient();
 
-    // Use deleteObject to send DELETE request
-    await client.deleteObject({
+    const response = await client.deleteObject({
       url: validated.calendar_url,
       headers: {
         'Content-Type': 'text/calendar; charset=utf-8',
       },
     });
+    await assertDeleted(response, `calendar ${validated.calendar_url}`);
 
-    // Return formatted success with warning
     return formatCalendarDeleteSuccess(validated.calendar_url);
   },
 };

--- a/src/tools/calendar/delete-event.js
+++ b/src/tools/calendar/delete-event.js
@@ -1,6 +1,7 @@
 import { tsdavManager } from '../../tsdav-client.js';
 import { validateInput, deleteEventSchema } from '../../validation.js';
 import { formatSuccess } from '../../formatters.js';
+import { assertDeleted } from '../shared/helpers.js';
 
 /**
  * Delete a calendar event permanently
@@ -26,12 +27,13 @@ export const deleteEvent = {
     const validated = validateInput(deleteEventSchema, args);
     const client = tsdavManager.getCalDavClient();
 
-    await client.deleteCalendarObject({
+    const response = await client.deleteCalendarObject({
       calendarObject: {
         url: validated.event_url,
         etag: validated.event_etag,
       },
     });
+    await assertDeleted(response, `event ${validated.event_url}`);
 
     return formatSuccess('Event deleted successfully');
   },

--- a/src/tools/contacts/delete-contact.js
+++ b/src/tools/contacts/delete-contact.js
@@ -1,6 +1,7 @@
 import { tsdavManager } from '../../tsdav-client.js';
 import { validateInput, deleteContactSchema } from '../../validation.js';
 import { formatSuccess } from '../../formatters.js';
+import { assertDeleted } from '../shared/helpers.js';
 
 /**
  * Delete a contact (vCard) permanently
@@ -26,12 +27,13 @@ export const deleteContact = {
     const validated = validateInput(deleteContactSchema, args);
     const client = tsdavManager.getCardDavClient();
 
-    await client.deleteVCard({
+    const response = await client.deleteVCard({
       vCard: {
         url: validated.vcard_url,
         etag: validated.vcard_etag,
       },
     });
+    await assertDeleted(response, `contact ${validated.vcard_url}`);
 
     return formatSuccess('Contact deleted successfully');
   },

--- a/src/tools/shared/helpers.js
+++ b/src/tools/shared/helpers.js
@@ -130,3 +130,39 @@ export function buildTimeRangeOptions(timeRangeStart, timeRangeEnd) {
 
   return options;
 }
+
+/**
+ * Assert that a DAV delete actually happened.
+ *
+ * tsdav's deleteObject — and the deleteCalendarObject / deleteVCard /
+ * deleteTodo wrappers around it — is a bare fetch, and fetch does not reject on
+ * 4xx or 5xx. An unchecked call therefore reports success for a 403 or 405 as
+ * happily as for a 204, which is how "the calendar is still there after I
+ * deleted it" becomes invisible to the caller.
+ *
+ * A 404 counts as done: DELETE is idempotent and the object is gone either way.
+ *
+ * @param {Response|undefined} response - what tsdav handed back
+ * @param {string} what - the object being deleted, for the error message
+ */
+export async function assertDeleted(response, what) {
+  // Not every tsdav version returns the raw Response; if we cannot see a
+  // status, we have nothing to check and must not invent a failure.
+  if (!response || typeof response.status !== 'number') return;
+
+  if (response.ok || response.status === 404) return;
+
+  let detail = '';
+  try {
+    const body = await response.text();
+    if (body) detail = `: ${body.slice(0, 200)}`;
+  } catch {
+    // body already consumed or not readable — the status is enough
+  }
+
+  throw new Error(
+    `Failed to delete ${what}: server responded ${response.status} ${response.statusText || ''}`.trim() +
+    detail +
+    '. The object still exists on the server.'
+  );
+}

--- a/src/tools/todos/delete-todo.js
+++ b/src/tools/todos/delete-todo.js
@@ -1,6 +1,7 @@
 import { tsdavManager } from '../../tsdav-client.js';
 import { validateInput, deleteTodoSchema } from '../../validation.js';
 import { formatSuccess } from '../../formatters.js';
+import { assertDeleted } from '../shared/helpers.js';
 
 /**
  * Delete a todo/task permanently
@@ -26,12 +27,13 @@ export const deleteTodo = {
     const validated = validateInput(deleteTodoSchema, args);
     const client = tsdavManager.getCalDavClient();
 
-    await client.deleteTodo({
+    const response = await client.deleteTodo({
       calendarObject: {
         url: validated.todo_url,
         etag: validated.todo_etag,
       },
     });
+    await assertDeleted(response, `todo ${validated.todo_url}`);
 
     return formatSuccess('Todo deleted successfully');
   },


### PR DESCRIPTION
Two independent places where the server told the truth and we discarded it.

### Deletes reported success unconditionally (#9)

`deleteObject` in tsdav is a bare `fetch`, and `fetch` does not reject on 4xx/5xx. All four delete tools awaited it, threw the Response away and returned "deleted successfully" — so a 403 or 405 was indistinguishable from a 204. That is how "the calendar is still there after I deleted it" stays invisible to the caller.

Worth correcting the framing in the issue: this is not Radicale-specific and needs no Radicale workaround. Every server was affected, and `deleteObject` already hands back the Response we were dropping. Whether Radicale additionally refuses collection DELETE is now a visible question rather than a silent one.

404 counts as done (DELETE is idempotent), and a tsdav build that returns no Response is not treated as a failure.

### Tool-call logging could corrupt the protocol stream (#48)

`TOOL_CALL_LOG_MODE=console` (or `both`) went through `console.log`, so under the stdio transport it wrote non-JSON-RPC lines onto the channel the protocol owns. `logger.js` already guarded against exactly this and warns about it in its header comment; the tool-call logger never shared the guard.

Both loggers now pick their sink through one small module — the narrow deduplication #25 was reaching for. The loggers themselves stay separate: an optional file analytics sink and the protocol-critical ops log are genuinely different consumers, and merging them would couple the two.

### Tests

150 passing, up from 138. Two new files covering refused deletes per tool, the idempotent 404 path, and both transports for the log sink.

Closes #9
Closes #48
Refs #25