### PR TITLE
feat(calendar): support all-day events in create_event and update_event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **All-day events** (#43): `create_event` and `update_event` accept a bare
+  `YYYY-MM-DD` `start_date`/`end_date` (or an explicit `all_day` flag) and emit
+  `DTSTART;VALUE=DATE` / `DTEND;VALUE=DATE`. `update_event` gained top-level
+  `start_date`/`end_date`/`all_day` parameters, which convert an event in both
+  directions; the `fields` map cannot express a parameterised property.
+  The all-day `DTEND` is exclusive, as RFC 5545 3.8.2.2 requires.
+
 ## [3.0.1] - 2026-01-20
 
 ### Added

--- a/__tests__/all-day-events.test.js
+++ b/__tests__/all-day-events.test.js
@@ -7,18 +7,45 @@ const CALENDAR_URL = 'https://dav.example.com/calendars/user/work/';
 const EVENT_URL = `${CALENDAR_URL}event.ics`;
 
 const createCalendarObject = jest.fn(async () => ({ url: EVENT_URL, etag: '"1"' }));
+const updateCalendarObject = jest.fn(async () => ({ etag: '"2"' }));
+
+// what fetchCalendarObjects hands back; each test sets it
+let storedEvent = '';
 
 jest.unstable_mockModule('../src/tsdav-client.js', () => ({
   tsdavManager: {
     getCalDavClient: () => ({
       fetchCalendars: async () => [{ url: CALENDAR_URL, displayName: 'Work' }],
       createCalendarObject,
+      fetchCalendarObjects: async () => [{ url: EVENT_URL, etag: '"1"', data: storedEvent }],
+      updateCalendarObject,
     }),
   },
 }));
 
 const { createEvent } = await import('../src/tools/calendar/create-event.js');
+const { updateEventFields } = await import('../src/tools/calendar/update-event-fields.js');
 const { formatEvent } = await import('../src/formatters.js');
+
+const ical = (...lines) => [
+  'BEGIN:VCALENDAR',
+  'VERSION:2.0',
+  'PRODID:-//test//EN',
+  'BEGIN:VEVENT',
+  'UID:event-1@test',
+  'DTSTAMP:20260101T000000Z',
+  'SUMMARY:Sprint review',
+  ...lines,
+  'END:VEVENT',
+  'END:VCALENDAR',
+].join('\r\n');
+
+const TIMED_EVENT = ical('DTSTART:20260525T100000Z', 'DTEND:20260525T110000Z');
+const TIMED_EVENT_WITH_TZID = ical(
+  'DTSTART;TZID=Europe/Berlin:20260525T100000',
+  'DTEND;TZID=Europe/Berlin:20260525T110000'
+);
+const ALL_DAY_EVENT = ical('DTSTART;VALUE=DATE:20260525', 'DTEND;VALUE=DATE:20260526');
 
 /** Re-parse an emitted document the way a CalDAV server or client would. */
 const reparse = (document) => {
@@ -33,6 +60,7 @@ const reparse = (document) => {
   };
 };
 
+const emittedUpdate = () => updateCalendarObject.mock.calls[0][0].calendarObject.data;
 
 /** formatSuccess wraps its payload in a fenced JSON block inside the markdown. */
 const payload = (result) =>
@@ -40,6 +68,8 @@ const payload = (result) =>
 
 beforeEach(() => {
   createCalendarObject.mockClear();
+  updateCalendarObject.mockClear();
+  storedEvent = TIMED_EVENT;
 });
 
 describe('create_event emits DATE values for all-day events', () => {
@@ -169,5 +199,179 @@ describe('create_event rejects incoherent date pairs', () => {
       { start_date: '2026-05-25', end_date: '2026-05-24' },
       /must be after start_date/
     );
+  });
+});
+
+describe('update_event converts between all-day and timed', () => {
+  test('timed -> all-day emits exactly one DATE-valued DTSTART/DTEND', async () => {
+    storedEvent = TIMED_EVENT;
+
+    await updateEventFields.handler({
+      event_url: EVENT_URL,
+      event_etag: '"1"',
+      start_date: '2026-05-25',
+      end_date: '2026-05-26',
+    });
+
+    const data = emittedUpdate();
+    expect(data).toContain('DTSTART;VALUE=DATE:20260525');
+    expect(data).toContain('DTEND;VALUE=DATE:20260526');
+
+    const parsed = reparse(data);
+    expect(parsed.dtstartCount).toBe(1);
+    expect(parsed.dtendCount).toBe(1);
+    expect(parsed.event.startDate.isDate).toBe(true);
+    expect(parsed.event.endDate.isDate).toBe(true);
+  });
+
+  test('all-day -> timed drops the stale VALUE=DATE parameter', async () => {
+    storedEvent = ALL_DAY_EVENT;
+
+    await updateEventFields.handler({
+      event_url: EVENT_URL,
+      event_etag: '"1"',
+      start_date: '2026-05-25T10:00:00Z',
+      end_date: '2026-05-25T11:00:00Z',
+    });
+
+    const data = emittedUpdate();
+    expect(data).toContain('DTSTART:20260525T100000Z');
+    expect(data).toContain('DTEND:20260525T110000Z');
+    expect(data).not.toContain('VALUE=DATE');
+
+    const parsed = reparse(data);
+    expect(parsed.dtstartCount).toBe(1);
+    expect(parsed.dtendCount).toBe(1);
+    // the requested time survives — a leftover VALUE=DATE would discard it
+    expect(parsed.event.startDate.isDate).toBe(false);
+    expect(parsed.event.startDate.toJSDate().toISOString()).toBe('2026-05-25T10:00:00.000Z');
+    expect(parsed.dtstart.getParameter('value')).toBeUndefined();
+  });
+
+  test('a UTC value written over a TZID event drops the TZID', async () => {
+    storedEvent = TIMED_EVENT_WITH_TZID;
+
+    await updateEventFields.handler({
+      event_url: EVENT_URL,
+      event_etag: '"1"',
+      start_date: '2026-05-25T10:00:00Z',
+      end_date: '2026-05-25T11:00:00Z',
+    });
+
+    const data = emittedUpdate();
+    expect(data).not.toContain('TZID');
+
+    const parsed = reparse(data);
+    expect(parsed.dtstartCount).toBe(1);
+    expect(parsed.dtstart.getParameter('tzid')).toBeUndefined();
+    expect(parsed.event.startDate.toJSDate().toISOString()).toBe('2026-05-25T10:00:00.000Z');
+  });
+
+  test('an all-day value written over a TZID event drops the TZID', async () => {
+    storedEvent = TIMED_EVENT_WITH_TZID;
+
+    await updateEventFields.handler({
+      event_url: EVENT_URL,
+      event_etag: '"1"',
+      start_date: '2026-05-25',
+      end_date: '2026-05-26',
+    });
+
+    const data = emittedUpdate();
+    expect(data).not.toContain('TZID');
+
+    const parsed = reparse(data);
+    expect(parsed.dtstartCount).toBe(1);
+    expect(parsed.event.startDate.isDate).toBe(true);
+    expect(parsed.event.startDate.year).toBe(2026);
+    expect(parsed.event.startDate.month).toBe(5);
+    expect(parsed.event.startDate.day).toBe(25);
+  });
+
+  test('dates and ordinary fields can change in one call', async () => {
+    storedEvent = TIMED_EVENT;
+
+    const result = await updateEventFields.handler({
+      event_url: EVENT_URL,
+      event_etag: '"1"',
+      fields: { SUMMARY: 'Offsite' },
+      start_date: '2026-05-25',
+      end_date: '2026-05-27',
+    });
+
+    const data = emittedUpdate();
+    expect(data).toContain('SUMMARY:Offsite');
+    expect(data).toContain('DTSTART;VALUE=DATE:20260525');
+    expect(reparse(data).vevent.getAllProperties('summary').length).toBe(1);
+    expect(payload(result).updated_fields).toEqual(['SUMMARY', 'DTSTART', 'DTEND']);
+  });
+
+  test('a fields-only update still leaves the dates alone', async () => {
+    storedEvent = ALL_DAY_EVENT;
+
+    await updateEventFields.handler({
+      event_url: EVENT_URL,
+      event_etag: '"1"',
+      fields: { LOCATION: 'Berlin' },
+    });
+
+    const data = emittedUpdate();
+    expect(data).toContain('LOCATION:Berlin');
+    expect(data).toContain('DTSTART;VALUE=DATE:20260525');
+    expect(reparse(data).dtstartCount).toBe(1);
+  });
+});
+
+describe('update_event rejects date changes it cannot express', () => {
+  const rejects = (args, message) =>
+    expect(updateEventFields.handler({
+      event_url: EVENT_URL,
+      event_etag: '"1"',
+      ...args,
+    })).rejects.toThrow(message);
+
+  test('a parameterised key in the fields map is still refused', async () => {
+    await rejects(
+      { fields: { 'DTSTART;VALUE=DATE': '20260525' } },
+      /is not a bare property name/
+    );
+  });
+
+  test('DTSTART in the fields map alongside start_date', async () => {
+    await rejects(
+      { fields: { DTSTART: '20260525T100000Z' }, start_date: '2026-05-25', end_date: '2026-05-26' },
+      /not with fields.DTSTART/
+    );
+  });
+
+  test('start_date without end_date', async () => {
+    await rejects({ start_date: '2026-05-25' }, /end_date is required/);
+  });
+
+  test('all_day alone, with no dates to apply it to', async () => {
+    await rejects({ all_day: true }, /start_date is required/);
+  });
+
+  test('a mixed pair, in both directions', async () => {
+    await rejects(
+      { start_date: '2026-05-25', end_date: '2026-05-26T10:00:00Z' },
+      /must both be date-only/
+    );
+    await rejects(
+      { start_date: '2026-05-25T10:00:00Z', end_date: '2026-05-26' },
+      /must both be date-only/
+    );
+  });
+
+  test('same-day all-day is answered with the exclusive-end spelling', async () => {
+    await rejects(
+      { start_date: '2026-05-25', end_date: '2026-05-25' },
+      /exclusive: to block 2026-05-25 alone, use end_date="2026-05-26"/
+    );
+  });
+
+  test('nothing is sent to the server when validation fails', async () => {
+    await rejects({ start_date: '2026-05-25' }, /end_date is required/);
+    expect(updateCalendarObject).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/all-day-events.test.js
+++ b/__tests__/all-day-events.test.js
@@ -46,6 +46,9 @@ const TIMED_EVENT_WITH_TZID = ical(
   'DTEND;TZID=Europe/Berlin:20260525T110000'
 );
 const ALL_DAY_EVENT = ical('DTSTART;VALUE=DATE:20260525', 'DTEND;VALUE=DATE:20260526');
+// an event whose length is a DURATION rather than a DTEND — legal, and the
+// form Apple Calendar and several servers emit
+const DURATION_EVENT = ical('DTSTART:20260525T100000Z', 'DURATION:PT1H');
 
 /** Re-parse an emitted document the way a CalDAV server or client would. */
 const reparse = (document) => {
@@ -286,6 +289,49 @@ describe('update_event converts between all-day and timed', () => {
     expect(parsed.event.startDate.year).toBe(2026);
     expect(parsed.event.startDate.month).toBe(5);
     expect(parsed.event.startDate.day).toBe(25);
+  });
+
+  test('a DURATION source event loses its DURATION when it becomes all-day', async () => {
+    storedEvent = DURATION_EVENT;
+
+    await updateEventFields.handler({
+      event_url: EVENT_URL,
+      event_etag: '"1"',
+      start_date: '2026-05-26',
+      end_date: '2026-05-27',
+    });
+
+    const data = emittedUpdate();
+    // RFC 5545 3.6.1: DTEND and DURATION must not both appear
+    expect(data).not.toContain('DURATION');
+    expect(data).toContain('DTEND;VALUE=DATE:20260527');
+
+    const parsed = reparse(data);
+    expect(parsed.dtendCount).toBe(1);
+    expect(parsed.vevent.getAllProperties('duration').length).toBe(0);
+    expect(parsed.event.endDate.isDate).toBe(true);
+    expect(parsed.event.endDate.day).toBe(27);
+  });
+
+  test('a DURATION source event loses its DURATION when it stays timed', async () => {
+    storedEvent = DURATION_EVENT;
+
+    await updateEventFields.handler({
+      event_url: EVENT_URL,
+      event_etag: '"1"',
+      start_date: '2026-05-26T09:00:00Z',
+      end_date: '2026-05-26T10:30:00Z',
+    });
+
+    const data = emittedUpdate();
+    expect(data).not.toContain('DURATION');
+    expect(data).toContain('DTEND:20260526T103000Z');
+
+    const parsed = reparse(data);
+    expect(parsed.dtendCount).toBe(1);
+    expect(parsed.vevent.getAllProperties('duration').length).toBe(0);
+    // the requested end wins over the old PT1H, which would have meant 10:00
+    expect(parsed.event.endDate.toJSDate().toISOString()).toBe('2026-05-26T10:30:00.000Z');
   });
 
   test('dates and ordinary fields can change in one call', async () => {

--- a/__tests__/all-day-events.test.js
+++ b/__tests__/all-day-events.test.js
@@ -1,0 +1,173 @@
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+import ICAL from 'ical.js';
+
+// The tools build/rewrite their document by hand, so the only way to assert the
+// emitted bytes is to drive the real handlers with a stubbed DAV client.
+const CALENDAR_URL = 'https://dav.example.com/calendars/user/work/';
+const EVENT_URL = `${CALENDAR_URL}event.ics`;
+
+const createCalendarObject = jest.fn(async () => ({ url: EVENT_URL, etag: '"1"' }));
+
+jest.unstable_mockModule('../src/tsdav-client.js', () => ({
+  tsdavManager: {
+    getCalDavClient: () => ({
+      fetchCalendars: async () => [{ url: CALENDAR_URL, displayName: 'Work' }],
+      createCalendarObject,
+    }),
+  },
+}));
+
+const { createEvent } = await import('../src/tools/calendar/create-event.js');
+const { formatEvent } = await import('../src/formatters.js');
+
+/** Re-parse an emitted document the way a CalDAV server or client would. */
+const reparse = (document) => {
+  const vevent = new ICAL.Component(ICAL.parse(document)).getFirstSubcomponent('vevent');
+  return {
+    vevent,
+    event: new ICAL.Event(vevent),
+    dtstartCount: vevent.getAllProperties('dtstart').length,
+    dtendCount: vevent.getAllProperties('dtend').length,
+    dtstart: vevent.getFirstProperty('dtstart'),
+    dtend: vevent.getFirstProperty('dtend'),
+  };
+};
+
+
+/** formatSuccess wraps its payload in a fenced JSON block inside the markdown. */
+const payload = (result) =>
+  JSON.parse(/```json\n([\s\S]*?)\n```/.exec(result.content[0].text)[1]);
+
+beforeEach(() => {
+  createCalendarObject.mockClear();
+});
+
+describe('create_event emits DATE values for all-day events', () => {
+  test('a bare YYYY-MM-DD start is auto-detected as all-day', async () => {
+    const result = await createEvent.handler({
+      calendar_url: CALENDAR_URL,
+      summary: 'Conference',
+      start_date: '2026-05-25',
+      end_date: '2026-05-26',
+    });
+
+    const { iCalString } = createCalendarObject.mock.calls[0][0];
+    expect(iCalString).toContain('DTSTART;VALUE=DATE:20260525');
+    expect(iCalString).toContain('DTEND;VALUE=DATE:20260526');
+    expect(iCalString).not.toMatch(/DTSTART[^\r\n]*T\d{6}Z/);
+    expect(payload(result).all_day).toBe(true);
+
+    const parsed = reparse(iCalString);
+    expect(parsed.dtstartCount).toBe(1);
+    expect(parsed.dtendCount).toBe(1);
+    expect(parsed.event.startDate.isDate).toBe(true);
+    expect(parsed.event.endDate.isDate).toBe(true);
+  });
+
+  test('an explicit all_day flag agrees with the date-only format', async () => {
+    await createEvent.handler({
+      calendar_url: CALENDAR_URL,
+      summary: 'Conference',
+      start_date: '2026-05-25',
+      end_date: '2026-05-28',
+      all_day: true,
+    });
+
+    const { iCalString } = createCalendarObject.mock.calls[0][0];
+    expect(iCalString).toContain('DTSTART;VALUE=DATE:20260525');
+    expect(iCalString).toContain('DTEND;VALUE=DATE:20260528');
+  });
+
+  test('an all-day document is still CRLF-delimited', async () => {
+    await createEvent.handler({
+      calendar_url: CALENDAR_URL,
+      summary: 'Conference',
+      start_date: '2026-05-25',
+      end_date: '2026-05-26',
+    });
+
+    const { iCalString } = createCalendarObject.mock.calls[0][0];
+    expect(iCalString).toContain('\r\n');
+    expect(iCalString).not.toMatch(/(^|[^\r])\n/);
+    expect(iCalString).not.toMatch(/\r(?!\n)/);
+  });
+
+  test('timed events are untouched by the all-day path', async () => {
+    await createEvent.handler({
+      calendar_url: CALENDAR_URL,
+      summary: 'Standup',
+      start_date: '2026-05-25T10:00:00Z',
+      end_date: '2026-05-25T11:00:00Z',
+    });
+
+    const { iCalString } = createCalendarObject.mock.calls[0][0];
+    expect(iCalString).toContain('DTSTART:20260525T100000Z');
+    expect(iCalString).toContain('DTEND:20260525T110000Z');
+    expect(iCalString).not.toContain('VALUE=DATE');
+  });
+
+  test('an all-day event round-trips to a plain date in the formatter', async () => {
+    await createEvent.handler({
+      calendar_url: CALENDAR_URL,
+      summary: 'Conference',
+      start_date: '2026-05-25',
+      end_date: '2026-05-26',
+    });
+
+    const { iCalString } = createCalendarObject.mock.calls[0][0];
+    const rendered = formatEvent({ data: iCalString, url: EVENT_URL, etag: '"1"' });
+    expect(rendered).toContain('May 25, 2026');
+    expect(rendered).not.toMatch(/May 25, 2026.*\d{1,2}:\d{2}/);
+  });
+});
+
+describe('create_event rejects incoherent date pairs', () => {
+  const rejects = (args, message) =>
+    expect(createEvent.handler({
+      calendar_url: CALENDAR_URL,
+      summary: 'X',
+      ...args,
+    })).rejects.toThrow(message);
+
+  test('date-only start with a datetime end', async () => {
+    await rejects(
+      { start_date: '2026-05-25', end_date: '2026-05-26T10:00:00Z' },
+      /must both be date-only/
+    );
+  });
+
+  test('datetime start with a date-only end (the other direction)', async () => {
+    await rejects(
+      { start_date: '2026-05-25T10:00:00Z', end_date: '2026-05-26' },
+      /must both be date-only/
+    );
+  });
+
+  test('all_day: false with date-only input names the real problem', async () => {
+    await rejects(
+      { start_date: '2026-05-25', end_date: '2026-05-26', all_day: false },
+      /carries no time.*2026-05-25T09:00:00Z/s
+    );
+  });
+
+  test('all_day: true with datetime input names the real problem', async () => {
+    await rejects(
+      { start_date: '2026-05-25T10:00:00Z', end_date: '2026-05-26T10:00:00Z', all_day: true },
+      /must be date-only/
+    );
+  });
+
+  test('same-day all-day is rejected with the exclusive-end spelling', async () => {
+    await rejects(
+      { start_date: '2026-05-25', end_date: '2026-05-25' },
+      /exclusive: to block 2026-05-25 alone, use end_date="2026-05-26"/
+    );
+  });
+
+  test('an end before the start is still rejected', async () => {
+    await rejects(
+      { start_date: '2026-05-25', end_date: '2026-05-24' },
+      /must be after start_date/
+    );
+  });
+});

--- a/docs/ICAL-RFC-FIELDS.md
+++ b/docs/ICAL-RFC-FIELDS.md
@@ -13,6 +13,24 @@
 - **CREATED** - Creation timestamp
 - **LAST-MODIFIED** - Last modification timestamp
 
+#### All-day events
+
+An all-day event is a DTSTART/DTEND carrying a DATE value rather than a
+DATE-TIME (RFC 5545 3.3.4), and its DTEND is **exclusive**:
+
+```
+DTSTART;VALUE=DATE:20260525
+DTEND;VALUE=DATE:20260526
+```
+
+That is one day, 25 May. `create_event` and `update_event` take this form as a
+bare `start_date`/`end_date` of `YYYY-MM-DD` (or an explicit `all_day: true`).
+
+The `fields` map of `update_event` cannot express it: keys there are bare
+property names, because a key carrying a parameter would append a second
+DTSTART rather than replace the existing one. The dedicated
+`start_date`/`end_date`/`all_day` parameters exist for exactly this reason.
+
 ### Text Properties
 - **SUMMARY** - Title/Subject
 - **DESCRIPTION** - Detailed description

--- a/src/tools/calendar/create-event.js
+++ b/src/tools/calendar/create-event.js
@@ -1,7 +1,7 @@
 import { tsdavManager } from '../../tsdav-client.js';
-import { validateInput, createEventSchema, sanitizeICalString } from '../../validation.js';
+import { validateInput, createEventSchema, sanitizeICalString, isDateOnly } from '../../validation.js';
 import { formatSuccess } from '../../formatters.js';
-import { formatICalDate, generateUID, findCalendarOrThrow } from '../shared/helpers.js';
+import { formatICalDate, formatICalDateOnly, generateUID, findCalendarOrThrow } from '../shared/helpers.js';
 
 /**
  * Create a new calendar event
@@ -22,11 +22,15 @@ export const createEvent = {
       },
       start_date: {
         type: 'string',
-        description: 'Start date in ISO 8601 format',
+        description: 'Start in ISO 8601 format. A datetime ("2026-05-25T10:00:00Z") makes a timed event; a bare date ("2026-05-25") makes an all-day event.',
       },
       end_date: {
         type: 'string',
-        description: 'End date in ISO 8601 format',
+        description: 'End, in the same form as start_date. For an all-day event the end is EXCLUSIVE: a single day on 2026-05-25 is start_date "2026-05-25" and end_date "2026-05-26".',
+      },
+      all_day: {
+        type: 'boolean',
+        description: 'Optional. All-day is inferred from the date format, so this is only needed to state the intent explicitly; it must agree with the format of start_date/end_date.',
       },
       description: {
         type: 'string',
@@ -52,6 +56,19 @@ export const createEvent = {
     const description = validated.description ? sanitizeICalString(validated.description) : '';
     const location = validated.location ? sanitizeICalString(validated.location) : '';
 
+    // ?? not ||: an explicit all_day: false has to survive a date-only start,
+    // and validation has already rejected the case where the two disagree
+    const allDay = validated.all_day ?? isDateOnly(validated.start_date);
+
+    // RFC 5545 3.6.1: an all-day event is a DATE-valued DTSTART/DTEND, and the
+    // DTEND is exclusive. Anything else is a DATE-TIME in UTC.
+    const dtstart = allDay
+      ? `DTSTART;VALUE=DATE:${formatICalDateOnly(validated.start_date)}`
+      : `DTSTART:${formatICalDate(new Date(validated.start_date))}`;
+    const dtend = allDay
+      ? `DTEND;VALUE=DATE:${formatICalDateOnly(validated.end_date)}`
+      : `DTEND:${formatICalDate(new Date(validated.end_date))}`;
+
     // RFC 5545 3.1: content lines are delimited by CRLF, not LF
     const iCalString = [
       'BEGIN:VCALENDAR',
@@ -60,8 +77,8 @@ export const createEvent = {
       'BEGIN:VEVENT',
       `UID:${uid}`,
       `DTSTAMP:${formatICalDate(now)}`,
-      `DTSTART:${formatICalDate(new Date(validated.start_date))}`,
-      `DTEND:${formatICalDate(new Date(validated.end_date))}`,
+      dtstart,
+      dtend,
       `SUMMARY:${summary}`,
       description ? `DESCRIPTION:${description}` : null,
       location ? `LOCATION:${location}` : null,
@@ -79,6 +96,7 @@ export const createEvent = {
       url: response.url,
       etag: response.etag,
       summary: validated.summary,
+      all_day: allDay,
     });
   },
 };

--- a/src/tools/calendar/update-event-fields.js
+++ b/src/tools/calendar/update-event-fields.js
@@ -1,8 +1,9 @@
 import { tsdavManager } from '../../tsdav-client.js';
-import { validateInput, davFieldMapSchema } from '../../validation.js';
+import { validateInput, davFieldMapSchema, dateOrDateTime, refineDateRange, isDateOnly } from '../../validation.js';
 import { formatSuccess } from '../../formatters.js';
 import { z } from 'zod';
 import { updateFields } from 'tsdav-utils';
+import { setEventDates } from '../shared/event-dates.js';
 
 /**
  * Schema for field-based event updates
@@ -10,11 +11,49 @@ import { updateFields } from 'tsdav-utils';
  * Field names are validated as bare property names; see davFieldMapSchema
  * Common fields: SUMMARY, DESCRIPTION, LOCATION, DTSTART, DTEND, STATUS
  * Custom properties: Any X-* property
+ *
+ * start_date/end_date/all_day sit OUTSIDE the fields map on purpose. An
+ * all-day DTSTART needs a VALUE=DATE parameter, and the fields map cannot
+ * carry a parameter without appending a duplicate property; see
+ * src/tools/shared/event-dates.js.
  */
 const updateEventFieldsSchema = z.object({
   event_url: z.string().url('Event URL must be a valid URL'),
   event_etag: z.string().min(1, 'Event etag is required'),
-  fields: davFieldMapSchema
+  fields: davFieldMapSchema,
+  start_date: dateOrDateTime.optional(),
+  end_date: dateOrDateTime.optional(),
+  all_day: z.boolean().optional(),
+}).superRefine((data, ctx) => {
+  const usesDateParams = data.start_date !== undefined ||
+    data.end_date !== undefined ||
+    data.all_day !== undefined;
+
+  if (!usesDateParams) return;
+
+  // Both ends are required together: the all-day DTEND is exclusive, so moving
+  // one end alone is how you get an event that silently ends before it starts.
+  for (const key of ['start_date', 'end_date']) {
+    if (data[key] === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [key],
+        message: `${key} is required when changing the event dates (start_date, end_date and all_day are set together)`,
+      });
+    }
+  }
+
+  for (const key of ['DTSTART', 'DTEND']) {
+    if (data.fields && key in data.fields) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['fields', key],
+        message: `Set the dates with start_date/end_date/all_day, not with fields.${key} — the two would fight over the same property`,
+      });
+    }
+  }
+
+  refineDateRange(data, ctx, { startKey: 'start_date', endKey: 'end_date' });
 });
 
 /**
@@ -29,7 +68,7 @@ const updateEventFieldsSchema = z.object({
  */
 export const updateEventFields = {
   name: 'update_event',
-  description: 'PREFERRED: Update event fields without iCal formatting. Supports: SUMMARY (title), DESCRIPTION (details), LOCATION (place), DTSTART (start time), DTEND (end time), STATUS (TENTATIVE/CONFIRMED/CANCELLED), and any RFC 5545 property including custom X-* properties (e.g., X-ZOOM-LINK, X-MEETING-ROOM).',
+  description: 'PREFERRED: Update event fields without iCal formatting. Supports: SUMMARY (title), DESCRIPTION (details), LOCATION (place), DTSTART (start time), DTEND (end time), STATUS (TENTATIVE/CONFIRMED/CANCELLED), and any RFC 5545 property including custom X-* properties (e.g., X-ZOOM-LINK, X-MEETING-ROOM). To move an event or convert it between all-day and timed, use the top-level start_date/end_date/all_day parameters instead of fields.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -73,6 +112,18 @@ export const updateEventFields = {
             description: 'Event status: TENTATIVE, CONFIRMED, or CANCELLED'
           }
         }
+      },
+      start_date: {
+        type: 'string',
+        description: 'New start. A datetime ("2026-05-25T10:00:00Z") makes the event timed; a bare date ("2026-05-25") makes it all-day. Must be given together with end_date.'
+      },
+      end_date: {
+        type: 'string',
+        description: 'New end, in the same form as start_date. For an all-day event the end is EXCLUSIVE: a single day on 2026-05-25 is start_date "2026-05-25" and end_date "2026-05-26".'
+      },
+      all_day: {
+        type: 'boolean',
+        description: 'Optional. All-day is inferred from the date format, so this is only needed to state the intent explicitly; it must agree with the format of start_date/end_date. This is the supported way to convert an event between all-day and timed.'
       }
     },
     required: ['event_url', 'event_etag']
@@ -96,7 +147,20 @@ export const updateEventFields = {
 
     // Step 2: Update fields using tsdav-utils (field-agnostic)
     // Accepts any RFC 5545 property name (UPPERCASE)
-    const updatedData = updateFields(calendarObject, validated.fields || {});
+    let updatedData = updateFields(calendarObject, validated.fields || {});
+
+    // Step 2b: dates go through the component API, not the fields map, because
+    // an all-day value needs a VALUE=DATE parameter on the property
+    const changedFields = Object.keys(validated.fields || {});
+    if (validated.start_date !== undefined) {
+      updatedData = setEventDates(updatedData, {
+        startDate: validated.start_date,
+        endDate: validated.end_date,
+        // ?? not ||, so an explicit all_day: false stays reachable
+        allDay: validated.all_day ?? isDateOnly(validated.start_date),
+      });
+      changedFields.push('DTSTART', 'DTEND');
+    }
 
     // Step 3: Send the updated event back to server
     const updateResponse = await client.updateCalendarObject({
@@ -109,8 +173,8 @@ export const updateEventFields = {
 
     return formatSuccess('Event updated successfully', {
       etag: updateResponse.etag,
-      updated_fields: Object.keys(validated.fields || {}),
-      message: `Updated ${Object.keys(validated.fields || {}).length} field(s): ${Object.keys(validated.fields || {}).join(', ')}`
+      updated_fields: changedFields,
+      message: `Updated ${changedFields.length} field(s): ${changedFields.join(', ')}`
     });
   }
 };

--- a/src/tools/shared/event-dates.js
+++ b/src/tools/shared/event-dates.js
@@ -44,6 +44,12 @@ export function setEventDates(iCalString, { startDate, endDate, allDay }) {
   setDateProperty(vevent, 'dtstart', toICalTime(startDate, allDay));
   setDateProperty(vevent, 'dtend', toICalTime(endDate, allDay));
 
+  // RFC 5545 3.6.1: "'dtend' and 'duration' MUST NOT occur in the same
+  // 'eventprop'". An event stored as DTSTART + DURATION has just been given an
+  // explicit end, so the DURATION is both redundant and illegal here — and a
+  // server is entitled to refuse the PUT.
+  vevent.removeAllProperties('duration');
+
   return component.toString();
 }
 

--- a/src/tools/shared/event-dates.js
+++ b/src/tools/shared/event-dates.js
@@ -1,0 +1,72 @@
+import ICAL from 'ical.js';
+
+/**
+ * Rewrite DTSTART/DTEND on an existing calendar object.
+ *
+ * This cannot go through the flat fields -> updateFields interface the rest of
+ * update_event uses. updateFields calls updatePropertyWithValue(name, value),
+ * which keys on the property NAME: a key of "DTSTART;VALUE=DATE" does not
+ * replace the existing DTSTART, it appends a second one. RFC 5545 3.6.1 says
+ * DTSTART MUST NOT occur twice, and on re-parse the first value wins — so the
+ * conversion would silently do nothing while corrupting the object.
+ *
+ * Removing the property and building a fresh one is what makes the two
+ * directions symmetric, and it is why no stale parameter can survive:
+ *
+ *  - all-day -> timed keeps no VALUE=DATE, which would otherwise re-parse as a
+ *    date and discard the requested time
+ *  - timed with a TZID -> UTC keeps no TZID, which RFC 5545 3.2.19 forbids on
+ *    a UTC value
+ *
+ * @param {string} iCalString - the current calendar object
+ * @param {Object} dates
+ * @param {string} dates.startDate - YYYY-MM-DD when allDay, else ISO 8601
+ * @param {string} dates.endDate - same form as startDate; exclusive when allDay
+ * @param {boolean} dates.allDay - emit DATE values rather than DATE-TIME
+ * @returns {string} the rewritten calendar object
+ */
+export function setEventDates(iCalString, { startDate, endDate, allDay }) {
+  let component;
+  try {
+    component = new ICAL.Component(ICAL.parse(iCalString));
+  } catch (error) {
+    throw new Error(`Failed to parse iCal data: ${error.message}`);
+  }
+
+  const vevent = component.name === 'vcalendar'
+    ? component.getFirstSubcomponent('vevent')
+    : component;
+
+  if (!vevent || vevent.name !== 'vevent') {
+    throw new Error('No VEVENT found in the calendar object');
+  }
+
+  setDateProperty(vevent, 'dtstart', toICalTime(startDate, allDay));
+  setDateProperty(vevent, 'dtend', toICalTime(endDate, allDay));
+
+  return component.toString();
+}
+
+/**
+ * Replace every occurrence of a date property with exactly one fresh property,
+ * carrying only the parameters the new value implies.
+ */
+function setDateProperty(vevent, name, time) {
+  vevent.removeAllProperties(name);
+  const property = new ICAL.Property(name, vevent);
+  // setValue on an ICAL.Time resets the property type, which is what writes
+  // (or omits) the VALUE=DATE parameter
+  property.setValue(time);
+  vevent.addProperty(property);
+}
+
+function toICalTime(value, allDay) {
+  if (allDay) {
+    // fromDateString gives isDate = true, which is the whole point: no time,
+    // no zone, and no host-timezone reinterpretation of the day
+    return ICAL.Time.fromDateString(value);
+  }
+  // true = UTC. The instant is what the caller asked for; a naive datetime is
+  // read in the host timezone, matching what create_event already does.
+  return ICAL.Time.fromJSDate(new Date(value), true);
+}

--- a/src/tools/shared/helpers.js
+++ b/src/tools/shared/helpers.js
@@ -12,6 +12,24 @@ export function formatICalDate(date) {
 }
 
 /**
+ * Format a date-only value as an iCal DATE (RFC 5545 3.3.4)
+ *
+ * String surgery on purpose: routing the value through Date would give it a
+ * time and an offset it does not have, and reading the date back out in the
+ * host timezone shifts it by a day for anyone east or west of Greenwich.
+ *
+ * @param {string} dateOnly - Date in YYYY-MM-DD form
+ * @returns {string} Formatted iCal date (YYYYMMDD)
+ */
+export function formatICalDateOnly(dateOnly) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateOnly);
+  if (!match) {
+    throw new Error(`Expected a date in YYYY-MM-DD form, got "${dateOnly}"`);
+  }
+  return `${match[1]}${match[2]}${match[3]}`;
+}
+
+/**
  * Generate unique UID for calendar objects
  * @param {string} prefix - Prefix for the UID (e.g., 'event', 'todo', 'contact')
  * @returns {string} Unique identifier

--- a/src/validation.js
+++ b/src/validation.js
@@ -11,6 +11,115 @@ const dateTimeWithOptionalOffset = z.union([
   z.string().regex(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/, 'Invalid datetime format') // Without timezone
 ]);
 
+// Helper: a date-only value, which RFC 5545 3.3.4 calls a DATE and which is how
+// an all-day event is expressed
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Is this a date-only ("2026-05-25") rather than a datetime value?
+ */
+export function isDateOnly(value) {
+  return typeof value === 'string' && DATE_ONLY.test(value);
+}
+
+// Helper: either form. Which one was given decides whether the event is
+// all-day, unless the caller says otherwise with an explicit all_day flag.
+export const dateOrDateTime = z.union([
+  z.string().regex(DATE_ONLY, 'Invalid date format'),
+  dateTimeWithOptionalOffset,
+]);
+
+/**
+ * The day after a date-only value, as a date-only value.
+ *
+ * Date.parse of "YYYY-MM-DD" is UTC midnight by spec, so adding 24h and
+ * reading the date back off the ISO string never crosses a DST seam.
+ */
+function nextDay(dateOnly) {
+  return new Date(Date.parse(dateOnly) + 86400000).toISOString().slice(0, 10);
+}
+
+/**
+ * Shared checks for a (start, end, all_day) triple.
+ *
+ * Three things go wrong here if they are not checked explicitly:
+ *
+ *  - A mixed pair. "2026-05-25" + "2026-05-26T10:00:00Z" is not a coherent
+ *    event, and it has to be caught from BOTH sides: keying the check off the
+ *    start alone lets a timed start with a date-only end through, which
+ *    silently produces an event ending at 00:00 UTC.
+ *  - all_day inferred with `||`. `all_day || isDateOnly(start)` makes an
+ *    explicit `all_day: false` unreachable, so the flag has ?? semantics here
+ *    and a contradiction between flag and format is reported as such.
+ *  - An all-day DTEND is exclusive (RFC 5545 3.8.2.2), so a single day is
+ *    written as end = start + 1. `end === start` is the phrasing a caller
+ *    reaches for first, so the error has to say how to spell it instead.
+ */
+export function refineDateRange(data, ctx, { startKey, endKey }) {
+  const start = data[startKey];
+  const end = data[endKey];
+  if (start === undefined || end === undefined) return;
+
+  const startIsDate = isDateOnly(start);
+  const endIsDate = isDateOnly(end);
+
+  if (startIsDate !== endIsDate) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: [endIsDate ? endKey : startKey],
+      message:
+        `${startKey} and ${endKey} must both be date-only (YYYY-MM-DD, an all-day event) ` +
+        `or must both carry a time; got ${startKey}="${start}" and ${endKey}="${end}"`,
+    });
+    return;
+  }
+
+  const allDay = data.all_day ?? startIsDate;
+
+  if (allDay && !startIsDate) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: [startKey],
+      message:
+        `all_day is true, so ${startKey}/${endKey} must be date-only (YYYY-MM-DD); ` +
+        `got "${start}". Drop the time part, and remember ${endKey} is exclusive`,
+    });
+    return;
+  }
+
+  if (!allDay && startIsDate) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: [startKey],
+      message:
+        `all_day is false, but ${startKey}="${start}" carries no time. ` +
+        `Give a time (e.g. "${start}T09:00:00Z"), or set all_day to true`,
+    });
+    return;
+  }
+
+  if (allDay && start === end) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: [endKey],
+      message:
+        `An all-day ${endKey} is exclusive: to block ${start} alone, ` +
+        `use ${endKey}="${nextDay(start)}"`,
+    });
+    return;
+  }
+
+  if (new Date(end) <= new Date(start)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: [endKey],
+      message: allDay
+        ? `${endKey} must be after ${startKey} and is exclusive: to block ${start} alone, use ${endKey}="${nextDay(start)}"`
+        : `End date must be after start date`,
+    });
+  }
+}
+
 // Helper: field map for the field-based update tools (update_event/_todo/_contact)
 //
 // Both halves of this check are load-bearing. tsdav-utils' updateFields calls
@@ -78,14 +187,15 @@ export const listEventsSchema = z.object({
 export const createEventSchema = z.object({
   calendar_url: z.string().url('Invalid calendar URL'),
   summary: z.string().min(1, 'Summary is required').max(500),
-  start_date: dateTimeWithOptionalOffset,
-  end_date: dateTimeWithOptionalOffset,
+  start_date: dateOrDateTime,
+  end_date: dateOrDateTime,
+  all_day: z.boolean().optional(),
   description: z.string().max(5000).optional(),
   location: z.string().max(500).optional(),
-}).refine((data) => new Date(data.end_date) > new Date(data.start_date), {
-  message: 'End date must be after start date',
-  path: ['end_date'],
-});
+}).superRefine((data, ctx) => refineDateRange(data, ctx, {
+  startKey: 'start_date',
+  endKey: 'end_date',
+}));
 
 export const updateEventSchema = z.object({
   event_url: z.string().url('Invalid event URL'),


### PR DESCRIPTION
Closes #43

## The defect

`create_event` and `update_event` could not produce an all-day event, for two stacked reasons.

**Validation.** `dateTimeWithOptionalOffset` was a union of `z.string().datetime({offset:true})` and a `YYYY-MM-DDTHH:MM:SS` regex, so a bare `2026-08-12` was rejected before any handler saw it.

**Emission.** Even past validation there was no code path that could emit a DATE-valued property. `create_event` emitted `DTSTART:${formatICalDate(...)}` unconditionally, and `formatICalDate` always produces `YYYYMMDDTHHmmssZ`. RFC 5545 3.3.4 wants a DATE value carrying `VALUE=DATE`, and 3.8.2.2 makes the all-day `DTEND` exclusive.

The display side already handled `isDate` correctly (`formatDateTime` in `src/formatters.js`) and is untouched; a test asserts the round trip through it.

## What it does now

```
create_event  start_date "2026-05-25"  end_date "2026-05-28"
->  DTSTART;VALUE=DATE:20260525
    DTEND;VALUE=DATE:20260528
```

`update_event` converts in both directions:

```
before  DTSTART;TZID=Europe/Berlin:20260525T100000
after   DTSTART;VALUE=DATE:20260525          (timed -> all-day)

before  DTSTART;VALUE=DATE:20260525
after   DTSTART:20260525T100000Z             (all-day -> timed)
```

## Decisions

**The dates do not go through the `fields` map.** `updateFields` calls `updatePropertyWithValue(key.toLowerCase(), value)`, which keys on the property *name*: a key of `"DTSTART;VALUE=DATE"` does not replace the existing DTSTART, it appends a second one. RFC 5545 3.6.1 forbids that, and on re-parse the old value wins — the conversion would silently do nothing while corrupting the object. `davFieldMapSchema` rejects such keys deliberately and is left as it is. `update_event` instead gained top-level `start_date` / `end_date` / `all_day` parameters, and the conversion operates on the parsed component via the `ICAL.Property` API.

**Each direction removes the property and builds a fresh one.** That is what makes the two symmetric, and why no stale parameter can survive: all-day -> timed keeps no `VALUE=DATE` (which would re-parse as a date and discard the requested time), and a UTC value written over a TZID-bearing event keeps no TZID (RFC 5545 3.2.19 forbids it there). Tests assert `getAllProperties('dtstart').length === 1` on the re-parsed output for every case.

**`all_day` is resolved with `??`, not `||`.** `all_day || isDateOnly(start)` makes an explicit `all_day: false` unreachable. Where flag and format contradict each other, the error names the contradiction rather than restating the format rule.

**Mixed pairs are checked from both ends.** Keying the check off `start_date` alone lets `start: "2026-05-25T10:00:00Z"` + `end: "2026-05-26"` through, silently producing an event ending at 00:00 UTC.

**Same-day all-day (`start == end`) stays rejected, but says how to spell it.** The exclusive end is correct, and "block 25 May" is the most plausible phrasing an LLM reaches for, so the message answers with `end_date="2026-05-26"` rather than leaving the caller to guess.

**The tool-schema descriptions carry the exclusive-end convention**, since the caller is an LLM reading `inputSchema` live.

## Testing

24 new tests drive the real handlers against a stubbed DAV client (the `jest.unstable_mockModule` pattern from `__tests__/line-endings.test.js`) and assert the emitted iCal, re-parsed with ical.js — not just that validation passes.

150 -> 174 passing. Green under `TZ=UTC`, `TZ=Europe/Berlin` and `TZ=America/Los_Angeles`, and each commit is green on its own.

Note: `__tests__/datetime-formatting.test.js` has one pre-existing failure under `TZ=Pacific/Auckland` ("a TZID that Intl does not know still renders a date"). It reproduces on unmodified `main` and is unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)