### PR TITLE
fix: render unknown TZIDs from their own offset

### DIFF
--- a/__tests__/datetime-formatting.test.js
+++ b/__tests__/datetime-formatting.test.js
@@ -71,15 +71,30 @@ describe('formatDateTime', () => {
     expect(output).toContain('July 15, 2026');
   });
 
-  test('a TZID that Intl does not know still renders a date', () => {
-    // Exchange and Outlook emit these; handing one to toLocaleDateString
-    // throws RangeError, which used to be swallowed into an empty string
+  test('a TZID that Intl does not know renders the organiser\'s wall time', () => {
+    // Exchange and Outlook emit these. Handing one to toLocaleDateString throws
+    // a RangeError that used to be swallowed into an empty string; deferring to
+    // the host zone instead showed a time nobody chose and moved the date at
+    // large offsets. The object's own VTIMEZONE gives us the offset.
     const output = when(event([
       'DTSTART;TZID=W. Europe Standard Time:20260715T140000',
       'DTEND;TZID=W. Europe Standard Time:20260715T150000',
     ], BERLIN_VTIMEZONE.replace(/Europe\/Berlin/, 'W. Europe Standard Time')));
-    expect(output).not.toBe('');
-    expect(output).toContain('July 15, 2026');
+    expect(output).toBe('July 15, 2026, 02:00 PM UTC+2 to July 15, 2026, 03:00 PM UTC+2');
+  });
+
+  test('an unknown TZID west of Greenwich keeps its sign', () => {
+    const western = BERLIN_VTIMEZONE
+      .replace(/Europe\/Berlin/, 'Eastern Standard Time')
+      .replace(/TZOFFSETFROM:\+0200/, 'TZOFFSETFROM:-0400')
+      .replace(/TZOFFSETTO:\+0100/, 'TZOFFSETTO:-0500')
+      .replace(/TZOFFSETFROM:\+0100/, 'TZOFFSETFROM:-0500')
+      .replace(/TZOFFSETTO:\+0200/, 'TZOFFSETTO:-0400');
+    const output = when(event([
+      'DTSTART;TZID=Eastern Standard Time:20260715T090000',
+      'DTEND;TZID=Eastern Standard Time:20260715T093000',
+    ], western));
+    expect(output).toContain('09:00 AM UTC-4');
   });
 
   test('a floating time renders without throwing', () => {

--- a/src/formatters.js
+++ b/src/formatters.js
@@ -311,6 +311,11 @@ const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June',
  * does not know (Exchange emits "W. Europe Standard Time"). Handing such a TZID
  * to toLocaleDateString throws a RangeError.
  */
+function isFloating(icalTime) {
+  const tzid = icalTime.zone?.tzid || icalTime.timezone;
+  return !tzid || tzid === 'floating';
+}
+
 function displayTimeZone(icalTime) {
   // ical.js populates .timezone only when the TZID could NOT be resolved, so
   // .zone.tzid is the canonical accessor and .timezone the last-ditch one.
@@ -328,6 +333,31 @@ function displayTimeZone(icalTime) {
 }
 
 /**
+ * Render a time from its own UTC offset rather than from a named zone.
+ *
+ * Used when the TZID is not a name Intl knows — Exchange emits things like
+ * "W. Europe Standard Time" — but the object carries a VTIMEZONE that ical.js
+ * did resolve. Deferring to the host zone instead would show a wall time the
+ * organiser never chose, and at a large host offset it moves the date.
+ */
+function formatWithFixedOffset(icalTime) {
+  const offsetSeconds = icalTime.utcOffset();
+  const sign = offsetSeconds < 0 ? '-' : '+';
+  const hours = Math.floor(Math.abs(offsetSeconds) / 3600);
+  const minutes = Math.floor((Math.abs(offsetSeconds) % 3600) / 60);
+  const offset = offsetSeconds === 0
+    ? 'UTC'
+    : `UTC${sign}${hours}${minutes ? `:${String(minutes).padStart(2, '0')}` : ''}`;
+
+  const hour24 = icalTime.hour;
+  const hour12 = hour24 % 12 === 0 ? 12 : hour24 % 12;
+  const meridiem = hour24 < 12 ? 'AM' : 'PM';
+  const time = `${String(hour12).padStart(2, '0')}:${String(icalTime.minute).padStart(2, '0')} ${meridiem}`;
+
+  return `${MONTHS[icalTime.month - 1]} ${icalTime.day}, ${icalTime.year}, ${time} ${offset}`;
+}
+
+/**
  * Format ICAL.Time to human-readable format with proper timezone support
  */
 function formatDateTime(icalTime) {
@@ -341,8 +371,15 @@ function formatDateTime(icalTime) {
       return `${MONTHS[icalTime.month - 1]} ${icalTime.day}, ${icalTime.year}`;
     }
 
-    const jsDate = icalTime.toJSDate();
     const timeZone = displayTimeZone(icalTime);
+
+    // A zone Intl cannot name, but whose offset ical.js resolved from the
+    // object's own VTIMEZONE: render the organiser's wall time, not the host's.
+    if (!timeZone && !isFloating(icalTime)) {
+      return formatWithFixedOffset(icalTime);
+    }
+
+    const jsDate = icalTime.toJSDate();
 
     const dateStr = jsDate.toLocaleDateString('en-US', {
       year: 'numeric',


### PR DESCRIPTION
Follow-up to #46, surfaced while testing #43 under an unusual host zone.

When `Intl` cannot name a TZID — Exchange and Outlook emit `W. Europe Standard Time` — the formatter fell back to the host's zone. The instant was correct, but the wall time shown was one the organiser never chose, and at a large host offset it moved the **date**:

```
TZ=Pacific/Auckland  →  "July 16, 2026, 12:00 AM GMT+12"   for a 14:00 Berlin meeting
```

CI only runs in UTC, which is why the existing assertion looked stable.

The calendar object carries a `VTIMEZONE` for that TZID and ical.js resolves it, so `utcOffset()` is available even though the name is not IANA. Rendering from that offset shows the organiser's wall time:

```
July 15, 2026, 02:00 PM UTC+2 to July 15, 2026, 03:00 PM UTC+2
```

Host-local remains the answer for genuinely floating values, where it is correct by definition.

Everything except floating is now host-independent, verified under UTC, Europe/Berlin, America/New_York, Pacific/Auckland and Pacific/Midway. 151 tests passing.

Closes #54