### PR TITLE
fix: pin tsdav to the build that actually has the todo API

### DIFF
--- a/__tests__/tsdav-surface.test.js
+++ b/__tests__/tsdav-surface.test.js
@@ -1,0 +1,39 @@
+import { describe, test, expect } from '@jest/globals';
+import { DAVClient, makeAddressBook } from 'tsdav';
+
+// tsdav is installed from a git branch, so what a consumer gets is whatever
+// dist/ happened to be committed at that ref. A sync from upstream once
+// overwrote dist/ with a build that had no VTODO surface, which silently killed
+// six of the eight todo tools for everyone installing from npm while working
+// fine for anyone whose lockfile still pinned the older commit. This test makes
+// that failure loud at install time instead. See issue #41.
+describe('the tsdav build we install actually exposes what we call', () => {
+  const clientMethods = [
+    'fetchTodos',
+    'todoQuery',
+    'todoMultiGet',
+    'createTodo',
+    'updateTodo',
+    'deleteTodo',
+    'fetchCalendars',
+    'fetchCalendarObjects',
+    'createCalendarObject',
+    'updateCalendarObject',
+    'deleteCalendarObject',
+    'fetchAddressBooks',
+    'fetchVCards',
+    'createVCard',
+    'updateVCard',
+    'deleteVCard',
+    'deleteObject',
+  ];
+
+  test.each(clientMethods)('DAVClient.prototype.%s is a function', (method) => {
+    expect(typeof DAVClient.prototype[method]).toBe('function');
+  });
+
+  test('makeAddressBook is exported', () => {
+    // lost in the same upstream sync that dropped the todo API
+    expect(typeof makeAddressBook).toBe('function');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -5223,17 +5223,17 @@
       "license": "MIT"
     },
     "node_modules/tsdav": {
-      "version": "2.3.0",
-      "resolved": "git+ssh://git@github.com/PhilflowIO/tsdav.git#9937a73a319a513e840170da4bea2fda17075d1d",
+      "version": "2.3.1",
+      "resolved": "git+ssh://git@github.com/PhilflowIO/tsdav.git#d411d7853e8520150b4345943daa49690a83c9b5",
       "license": "MIT",
       "dependencies": {
         "base-64": "1.0.0",
         "cross-fetch": "4.1.0",
-        "debug": "4.4.1",
+        "debug": "4.4.3",
         "xml-js": "1.6.11"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/tsdav-utils": {
@@ -5245,23 +5245,6 @@
       },
       "peerDependencies": {
         "tsdav": "^2.0.0"
-      }
-    },
-    "node_modules/tsdav/node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/tslib": {


### PR DESCRIPTION
Consumer half of #41. The fix itself was in the fork — PhilflowIO/tsdav#30, merged.

## What was wrong

`package.json` asks for `github:PhilflowIO/tsdav#master`, but the lockfile still resolved a commit from 2025-11-06. An upstream sync had since overwritten the fork's committed `dist/` with a build that has no VTODO surface, and because `prepare` only ran husky, a git install never rebuilt — so consumers got the stale bundle. Six of the eight todo tools (`list_todos`, `todo_query`, `todo_multi_get`, `create_todo`, `update_todo`, `delete_todo`) were dead on npm while working perfectly for anyone whose lockfile pinned the older commit. That asymmetry is why the issue sat open since April.

`makeAddressBook` was lost in the same sync, which nobody had noticed.

## What changed here

The pin moves to the rebuilt fork (2.3.1). The fork now rebuilds `dist/` on install, so a git install cannot serve a stale bundle again even if the committed one drifts.

`__tests__/tsdav-surface.test.js` asserts that every client method this server calls actually exists on the installed `DAVClient.prototype`, plus the `makeAddressBook` export. A repeat is now a red suite at install time rather than a runtime error inside a tool call.

## Verification

```
fetchTodos, todoQuery, todoMultiGet, createTodo, updateTodo, deleteTodo  → all functions
makeAddressBook → function
tsdav version: 2.3.1
```

195 tests passing, up from 177.

Closes #41