### PR TITLE
feat: cap query results and report what was left out

### DIFF
--- a/__tests__/result-limit.test.js
+++ b/__tests__/result-limit.test.js
@@ -1,0 +1,173 @@
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+import { limitResults, DEFAULT_RESULT_LIMIT } from '../src/tools/shared/helpers.js';
+
+const CALENDAR_URL = 'https://dav.example.com/calendars/user/work/';
+const ADDRESSBOOK_URL = 'https://dav.example.com/addressbooks/user/default/';
+
+const fetchCalendarObjects = jest.fn();
+const fetchVCards = jest.fn();
+
+jest.unstable_mockModule('../src/tsdav-client.js', () => ({
+  tsdavManager: {
+    getCalDavClient: () => ({
+      fetchCalendars: async () => [{ url: CALENDAR_URL, displayName: 'Work' }],
+      fetchCalendarObjects,
+    }),
+    getCardDavClient: () => ({
+      fetchAddressBooks: async () => [{ url: ADDRESSBOOK_URL, displayName: 'Default' }],
+      fetchVCards,
+    }),
+  },
+}));
+
+const { calendarQuery } = await import('../src/tools/calendar/calendar-query.js');
+const { addressbookQuery } = await import('../src/tools/contacts/addressbook-query.js');
+
+const event = (day, summary = 'Standup') => ({
+  url: `${CALENDAR_URL}${day}.ics`,
+  etag: '"1"',
+  data: [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'BEGIN:VEVENT',
+    `UID:${day}@example.com`,
+    `DTSTART:202605${String(day).padStart(2, '0')}T100000Z`,
+    `DTEND:202605${String(day).padStart(2, '0')}T110000Z`,
+    `SUMMARY:${summary}`,
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ].join('\r\n'),
+});
+
+const contact = (name) => ({
+  url: `${ADDRESSBOOK_URL}${name}.vcf`,
+  etag: '"1"',
+  data: [
+    'BEGIN:VCARD',
+    'VERSION:3.0',
+    `UID:${name}@example.com`,
+    `FN:${name}`,
+    `EMAIL;TYPE=INTERNET:${name.toLowerCase()}@example.com`,
+    'END:VCARD',
+  ].join('\r\n'),
+});
+
+describe('limitResults', () => {
+  test('returns everything when under the limit', () => {
+    const items = [event(3), event(1), event(2)];
+    const { items: result, total } = limitResults(items, 20, 'DTSTART');
+    expect(total).toBe(3);
+    expect(result).toHaveLength(3);
+    // untouched, so no needless reordering of a set that fits
+    expect(result).toBe(items);
+  });
+
+  test('sorts by date before truncating', () => {
+    const { items, total } = limitResults([event(9), event(3), event(21), event(1)], 2, 'DTSTART');
+    expect(total).toBe(4);
+    expect(items.map(i => i.url)).toEqual([`${CALENDAR_URL}1.ics`, `${CALENDAR_URL}3.ics`]);
+  });
+
+  test('a DATE and a DATE-TIME sort against each other correctly', () => {
+    const allDay = {
+      url: `${CALENDAR_URL}allday.ics`,
+      etag: '"1"',
+      data: 'BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nDTSTART;VALUE=DATE:20260502\r\nEND:VEVENT\r\nEND:VCALENDAR',
+    };
+    const { items } = limitResults([event(9), allDay, event(21)], 2, 'DTSTART');
+    expect(items.map(i => i.url)).toEqual([`${CALENDAR_URL}allday.ics`, `${CALENDAR_URL}9.ics`]);
+  });
+
+  test('objects missing the property sort last, not first', () => {
+    const undated = { url: `${CALENDAR_URL}none.ics`, etag: '"1"', data: 'BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nSUMMARY:No date\r\nEND:VEVENT\r\nEND:VCALENDAR' };
+    const { items } = limitResults([undated, event(9), event(3)], 2, 'DTSTART');
+    expect(items.map(i => i.url)).toEqual([`${CALENDAR_URL}3.ics`, `${CALENDAR_URL}9.ics`]);
+  });
+
+  test('sorts text properties alphabetically, case-insensitively', () => {
+    const { items } = limitResults(
+      [contact('Zoe'), contact('ada'), contact('Bob')], 2, 'FN', 'text'
+    );
+    expect(items.map(i => i.url)).toEqual([`${ADDRESSBOOK_URL}ada.vcf`, `${ADDRESSBOOK_URL}Bob.vcf`]);
+  });
+
+  test('does not mutate the input', () => {
+    const items = [event(9), event(3)];
+    limitResults(items, 1, 'DTSTART');
+    expect(items[0].url).toBe(`${CALENDAR_URL}9.ics`);
+  });
+});
+
+describe('query tools cap their results', () => {
+  beforeEach(() => {
+    fetchCalendarObjects.mockReset();
+    fetchVCards.mockReset();
+  });
+
+  const manyEvents = Array.from({ length: 40 }, (_, i) => event(i + 1));
+
+  test('calendar_query defaults to a cap and says what was left out', async () => {
+    fetchCalendarObjects.mockResolvedValue(manyEvents);
+    const text = (await calendarQuery.handler({
+      calendar_url: CALENDAR_URL,
+      summary_filter: 'Standup',
+    })).content[0].text;
+
+    expect(text).toContain(`Found events: **${DEFAULT_RESULT_LIMIT}** of 40`);
+    expect(text).toContain('narrow the query');
+  });
+
+  test('an explicit limit is honoured', async () => {
+    fetchCalendarObjects.mockResolvedValue(manyEvents);
+    const text = (await calendarQuery.handler({
+      calendar_url: CALENDAR_URL,
+      summary_filter: 'Standup',
+      limit: 3,
+    })).content[0].text;
+
+    expect(text).toContain('Found events: **3** of 40');
+  });
+
+  test('a result set under the limit is not annotated', async () => {
+    fetchCalendarObjects.mockResolvedValue([event(1), event(2)]);
+    const text = (await calendarQuery.handler({
+      calendar_url: CALENDAR_URL,
+      summary_filter: 'Standup',
+    })).content[0].text;
+
+    expect(text).toContain('Found events: **2**');
+    expect(text).not.toContain(' of ');
+  });
+
+  test('the capped set is the earliest, not an arbitrary slice', async () => {
+    fetchCalendarObjects.mockResolvedValue([event(28), event(2), event(15)]);
+    const text = (await calendarQuery.handler({
+      calendar_url: CALENDAR_URL,
+      summary_filter: 'Standup',
+      limit: 1,
+    })).content[0].text;
+
+    expect(text).toContain('May 2, 2026');
+    expect(text).not.toContain('May 28, 2026');
+  });
+
+  test('addressbook_query caps alphabetically', async () => {
+    fetchVCards.mockResolvedValue([contact('Zoe'), contact('Ada'), contact('Bob')]);
+    const text = (await addressbookQuery.handler({
+      addressbook_url: ADDRESSBOOK_URL,
+      email_filter: '@example.com',
+      limit: 1,
+    })).content[0].text;
+
+    expect(text).toContain('Found contacts: **1** of 3');
+  });
+
+  test('limit is validated', async () => {
+    fetchCalendarObjects.mockResolvedValue(manyEvents);
+    await expect(calendarQuery.handler({
+      calendar_url: CALENDAR_URL,
+      summary_filter: 'Standup',
+      limit: 0,
+    })).rejects.toThrow(/limit/);
+  });
+});

--- a/src/formatters.js
+++ b/src/formatters.js
@@ -274,6 +274,17 @@ export function stripBinaryValues(data) {
 }
 
 /**
+ * The count line, plus what was left out.
+ *
+ * Silent truncation reads as "this is everything", which is exactly the wrong
+ * thing to hand a model that is deciding whether it has enough to answer.
+ */
+function foundLine(noun, shown, total) {
+  if (!total || total <= shown) return `Found ${noun}: **${shown}**\n\n`;
+  return `Found ${noun}: **${shown}** of ${total} (showing the ${shown} earliest — raise \`limit\` or narrow the query to see the rest)\n\n`;
+}
+
+/**
  * Shape a list of DAV objects for the Raw Data block
  */
 function toRawData(items) {
@@ -474,7 +485,7 @@ export function formatEvent(event, calendar = 'Unknown Calendar', timeRange = nu
 /**
  * Format a list of calendar events to LLM-friendly Markdown
  */
-export function formatEventList(events, calendar = 'Unknown Calendar', timeRange = null) {
+export function formatEventList(events, calendar = 'Unknown Calendar', timeRange = null, total = null) {
   const calendarName = collectionName(calendar, 'Unknown Calendar');
 
   if (!events || events.length === 0) {
@@ -486,7 +497,7 @@ export function formatEventList(events, calendar = 'Unknown Calendar', timeRange
     };
   }
 
-  let output = `Found events: **${events.length}**\n\n`;
+  let output = foundLine('events', events.length, total);
 
   events.forEach((event, index) => {
     output += `### ${index + 1}. `;
@@ -589,7 +600,7 @@ export function formatContact(contact, addressBook = 'Unknown Address Book') {
 /**
  * Format a list of contacts to LLM-friendly Markdown
  */
-export function formatContactList(contacts, addressBook = 'Unknown Address Book') {
+export function formatContactList(contacts, addressBook = 'Unknown Address Book', total = null) {
   const addressBookName = collectionName(addressBook, 'Unknown Address Book');
 
   if (!contacts || contacts.length === 0) {
@@ -608,7 +619,7 @@ export function formatContactList(contacts, addressBook = 'Unknown Address Book'
     };
   }
 
-  let output = `Found contacts: **${contacts.length}**\n\n`;
+  let output = foundLine('contacts', contacts.length, total);
 
   contacts.forEach((contact, index) => {
     output += `### ${index + 1}. `;
@@ -921,7 +932,7 @@ export function formatTodo(todo, calendar = 'Unknown Calendar') {
 /**
  * Format a list of todos to LLM-friendly Markdown
  */
-export function formatTodoList(todos, calendar = 'Unknown Calendar') {
+export function formatTodoList(todos, calendar = 'Unknown Calendar', total = null) {
   const calendarName = collectionName(calendar, 'Unknown Calendar');
   if (!todos || todos.length === 0) {
     return {
@@ -932,7 +943,7 @@ export function formatTodoList(todos, calendar = 'Unknown Calendar') {
     };
   }
 
-  let output = `Found todos: **${todos.length}**\n\n`;
+  let output = foundLine('todos', todos.length, total);
 
   todos.forEach((todo, index) => {
     output += `### ${index + 1}. `;

--- a/src/tools/calendar/calendar-query.js
+++ b/src/tools/calendar/calendar-query.js
@@ -1,7 +1,7 @@
 import { tsdavManager } from '../../tsdav-client.js';
 import { validateInput, calendarQuerySchema } from '../../validation.js';
 import { formatEventList } from '../../formatters.js';
-import { buildTimeRangeOptions } from '../shared/helpers.js';
+import { buildTimeRangeOptions, limitResults, DEFAULT_RESULT_LIMIT } from '../shared/helpers.js';
 
 /**
  * Search and filter calendar events efficiently
@@ -31,6 +31,10 @@ export const calendarQuery = {
       location_filter: {
         type: 'string',
         description: 'Search event locations containing this text. Example: "Berlin", "Office", "Zoom". Can be used alone as sufficient filter.',
+      },
+      limit: {
+        type: 'number',
+        description: 'Maximum number of events to return (default 20, max 500). You get the earliest by start date, and the response states how many matched in total.',
       },
     },
     required: [],
@@ -89,6 +93,12 @@ export const calendarQuery = {
       ? calendarsToSearch[0]
       : `All Calendars (${calendarsToSearch.length})`;
 
-    return formatEventList(filteredEvents, calendarName, timeRangeOptions.timeRange);
+    const { items, total } = limitResults(
+      filteredEvents,
+      validated.limit ?? DEFAULT_RESULT_LIMIT,
+      'DTSTART'
+    );
+
+    return formatEventList(items, calendarName, timeRangeOptions.timeRange, total);
   },
 };

--- a/src/tools/contacts/addressbook-query.js
+++ b/src/tools/contacts/addressbook-query.js
@@ -1,6 +1,7 @@
 import { tsdavManager } from '../../tsdav-client.js';
 import { validateInput, addressBookQuerySchema } from '../../validation.js';
 import { formatContactList } from '../../formatters.js';
+import { limitResults, DEFAULT_RESULT_LIMIT } from '../shared/helpers.js';
 
 /**
  * Search and filter contacts efficiently
@@ -26,6 +27,10 @@ export const addressbookQuery = {
       organization_filter: {
         type: 'string',
         description: 'Search contact organizations/companies. Example: "Google" or "Acme Corp". At least one filter (name, email, or org) is required.',
+      },
+      limit: {
+        type: 'number',
+        description: 'Maximum number of contacts to return (default 20, max 500). You get them alphabetically by name, and the response states how many matched in total.',
       },
     },
     required: [],
@@ -82,6 +87,13 @@ export const addressbookQuery = {
       ? addressbooksToSearch[0]
       : `All Address Books (${addressbooksToSearch.length})`;
 
-    return formatContactList(filteredContacts, addressBookName);
+    const { items, total } = limitResults(
+      filteredContacts,
+      validated.limit ?? DEFAULT_RESULT_LIMIT,
+      'FN',
+      'text'
+    );
+
+    return formatContactList(items, addressBookName, total);
   },
 };

--- a/src/tools/shared/helpers.js
+++ b/src/tools/shared/helpers.js
@@ -184,3 +184,57 @@ export async function assertDeleted(response, what) {
     '. The object still exists on the server.'
   );
 }
+
+// Query tools return everything the server has in range, which for a wide
+// range is thousands of objects — and each one carries its full iCal body into
+// the model's context. A cap is the difference between a useful answer and an
+// overflowed one.
+export const DEFAULT_RESULT_LIMIT = 20;
+
+/**
+ * Extract a sortable key from a raw iCal/vCard body.
+ *
+ * Date properties normalise to digits so that a DATE ("20260525") and a
+ * DATE-TIME ("20260525T100000Z") sort against each other correctly, which they
+ * do not as raw strings. Text properties sort case-insensitively.
+ *
+ * A missing property sorts last either way: an object with no date is not
+ * "earliest", and an unnamed contact is not first.
+ */
+function sortKey(data, property, kind) {
+  const raw = data?.match(new RegExp(`^${property}[^:]*:(.+)$`, 'm'))?.[1]?.trim() || '';
+
+  if (kind === 'text') {
+    return raw ? raw.toLowerCase() : '\uffff';
+  }
+  const digits = raw.replace(/\D/g, '');
+  return digits ? digits.padEnd(14, '0') : '9'.repeat(14);
+}
+
+/**
+ * Sort by date and cap the result set.
+ *
+ * Truncating without sorting would hand back an arbitrary subset, which is
+ * worse than a smaller one: the caller cannot tell which events they are
+ * missing. Returns the total so the formatter can say what was left out —
+ * silent truncation reads as "this is everything".
+ *
+ * @param {Array} items - DAV objects with a `data` property
+ * @param {number} limit - maximum number of items to return
+ * @param {string} property - property to sort by (DTSTART, DUE, FN, ...)
+ * @param {'date'|'text'} kind - how to compare that property
+ * @returns {{ items: Array, total: number }}
+ */
+export function limitResults(items, limit, property, kind = 'date') {
+  const total = items.length;
+
+  if (!limit || total <= limit) {
+    return { items, total };
+  }
+
+  const sorted = [...items].sort(
+    (a, b) => sortKey(a.data, property, kind).localeCompare(sortKey(b.data, property, kind))
+  );
+
+  return { items: sorted.slice(0, limit), total };
+}

--- a/src/tools/todos/todo-query.js
+++ b/src/tools/todos/todo-query.js
@@ -1,6 +1,7 @@
 import { tsdavManager } from '../../tsdav-client.js';
 import { validateInput, todoQuerySchema } from '../../validation.js';
 import { formatTodoList } from '../../formatters.js';
+import { limitResults, DEFAULT_RESULT_LIMIT } from '../shared/helpers.js';
 
 /**
  * Search and filter todos efficiently
@@ -31,6 +32,10 @@ export const todoQuery = {
       time_range_end: {
         type: 'string',
         description: 'End datetime for due date filtering (ISO 8601). If provided, time_range_start is REQUIRED. Both dates together form a complete filter.',
+      },
+      limit: {
+        type: 'number',
+        description: 'Maximum number of todos to return (default 20, max 500). You get the earliest by due date, and the response states how many matched in total.',
       },
     },
     required: [],
@@ -103,6 +108,12 @@ export const todoQuery = {
       ? (calendarsToSearch[0].displayName || calendarsToSearch[0].url)
       : `All Calendars (${calendarsToSearch.length})`;
 
-    return formatTodoList(todos, calendarName);
+    const { items, total } = limitResults(
+      todos,
+      validated.limit ?? DEFAULT_RESULT_LIMIT,
+      'DUE'
+    );
+
+    return formatTodoList(items, calendarName, total);
   },
 };

--- a/src/validation.js
+++ b/src/validation.js
@@ -175,6 +175,11 @@ const optionalUrl = (message) =>
     z.string().url(message).optional()
   );
 
+// Helper: cap on how many objects a query may return. The caller is an LLM
+// whose context the result has to fit into, so the default is deliberately
+// small; the formatter says how many were left out.
+const resultLimit = z.number().int().min(1).max(500).optional();
+
 // CalDAV Schemas
 export const listCalendarsSchema = z.object({});
 
@@ -209,6 +214,7 @@ export const deleteEventSchema = z.object({
 });
 
 export const calendarQuerySchema = z.object({
+  limit: resultLimit,
   calendar_url: optionalUrl('Invalid calendar URL'),
   time_range_start: dateTimeWithOptionalOffset.optional(),
   time_range_end: dateTimeWithOptionalOffset.optional(),
@@ -288,6 +294,7 @@ export const deleteContactSchema = z.object({
 });
 
 export const addressBookQuerySchema = z.object({
+  limit: resultLimit,
   addressbook_url: optionalUrl('Invalid addressbook URL'),
   name_filter: z.string().optional(),
   email_filter: z.string().optional(),
@@ -333,6 +340,7 @@ export const deleteTodoSchema = z.object({
 });
 
 export const todoQuerySchema = z.object({
+  limit: resultLimit,
   calendar_url: optionalUrl('Invalid calendar URL'),
   summary_filter: z.string().optional(),
   status_filter: z.enum(['NEEDS-ACTION', 'IN-PROCESS', 'COMPLETED', 'CANCELLED']).optional(),


### PR DESCRIPTION
`calendar_query`, `todo_query` and `addressbook_query` returned every object the server had in range, each carrying its full iCal/vCard body into the model's context. A wide range meant thousands of objects and an overflow instead of an answer.

All three now take an optional `limit` (default 20, max 500).

**Sorting before truncating is the part that matters.** An arbitrary subset is worse than a smaller one, because the caller cannot tell what is missing. Events and todos come back earliest-first, contacts alphabetically. The count line states the total:

```
Found events: **20** of 137 (showing the 20 earliest — raise `limit` or narrow the query to see the rest)
```

Silent truncation reads as "this is everything", which is exactly the wrong thing to hand a model deciding whether it has enough to answer.

Two details worth noting: a DATE and a DATE-TIME sort correctly against each other (they do not as raw strings), and an object missing the sort property sorts **last** — an undated event is not "earliest".

### On #32

This closes it too, and I'd close it rather than build anything further. Your own comment there said "out of scope, add it to the system prompt", and the body says the workaround works. The failure mode was an absurd range producing 120k tokens; with a cap that degrades to 20 results plus a line saying how many matched. That is the real mitigation — no output cap teaches a model to ask for 7 days instead of 74 years, but it does stop the request from being fatal.

### On #33

These are the same mechanism at two levels and now share one path: #33 caps the size of a single item, this caps how many items there are. Either alone is insufficient — one contact with an embedded photo was ~43k tokens, so a limit would not have saved it, and stripping alone still returns 500 events for a wide range.

212 tests passing, up from 200.

Closes #34
Closes #32