### PR TITLE
feat: add freebusy_query, calculated client-side

### DIFF
--- a/__tests__/freebusy.test.js
+++ b/__tests__/freebusy.test.js
@@ -1,0 +1,244 @@
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+import { calculateFreeBusy } from '../src/tools/shared/freebusy.js';
+
+const CALENDAR_URL = 'https://dav.example.com/calendars/user/work/';
+
+const fetchCalendarObjects = jest.fn();
+
+jest.unstable_mockModule('../src/tsdav-client.js', () => ({
+  tsdavManager: {
+    getCalDavClient: () => ({
+      fetchCalendars: async () => [
+        { url: CALENDAR_URL, displayName: 'Work' },
+        { url: 'https://dav.example.com/calendars/user/home/', displayName: 'Home' },
+      ],
+      fetchCalendarObjects,
+    }),
+    getCardDavClient: () => ({}),
+  },
+}));
+
+const { freeBusyQuery } = await import('../src/tools/calendar/freebusy-query.js');
+
+const object = (properties) => ({
+  url: `${CALENDAR_URL}${Math.random().toString(36).slice(2)}.ics`,
+  etag: '"1"',
+  data: [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//Test//Test//EN',
+    'BEGIN:VEVENT',
+    'UID:e@example.com',
+    ...properties,
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ].join('\r\n'),
+});
+
+const meeting = (startHour, endHour, extra = []) => object([
+  `DTSTART:20260525T${String(startHour).padStart(2, '0')}0000Z`,
+  `DTEND:20260525T${String(endHour).padStart(2, '0')}0000Z`,
+  'SUMMARY:Meeting',
+  ...extra,
+]);
+
+const DAY = {
+  start: new Date('2026-05-25T09:00:00Z'),
+  end: new Date('2026-05-25T17:00:00Z'),
+};
+
+const hours = (intervals) => intervals.map(
+  i => `${i.start.toISOString().slice(11, 16)}-${i.end.toISOString().slice(11, 16)}`
+);
+
+describe('calculateFreeBusy', () => {
+  test('an empty calendar is free for the whole window', () => {
+    const { busy, free } = calculateFreeBusy([], DAY);
+    expect(busy).toEqual([]);
+    expect(hours(free)).toEqual(['09:00-17:00']);
+  });
+
+  test('one meeting splits the window', () => {
+    const { busy, free } = calculateFreeBusy([meeting(12, 13)], DAY);
+    expect(hours(busy)).toEqual(['12:00-13:00']);
+    expect(hours(free)).toEqual(['09:00-12:00', '13:00-17:00']);
+  });
+
+  test('overlapping meetings merge into one busy block', () => {
+    const { busy } = calculateFreeBusy([meeting(10, 12), meeting(11, 13)], DAY);
+    expect(hours(busy)).toEqual(['10:00-13:00']);
+  });
+
+  test('back-to-back meetings merge — a zero-length gap is not free time', () => {
+    const { busy, free } = calculateFreeBusy([meeting(10, 11), meeting(11, 12)], DAY);
+    expect(hours(busy)).toEqual(['10:00-12:00']);
+    expect(hours(free)).toEqual(['09:00-10:00', '12:00-17:00']);
+  });
+
+  test('a meeting inside another does not reopen free time', () => {
+    const { busy } = calculateFreeBusy([meeting(10, 15), meeting(11, 12)], DAY);
+    expect(hours(busy)).toEqual(['10:00-15:00']);
+  });
+
+  test('events are clipped to the window', () => {
+    const overnight = object([
+      'DTSTART:20260524T220000Z',
+      'DTEND:20260525T100000Z',
+      'SUMMARY:Long haul',
+    ]);
+    const { busy, free } = calculateFreeBusy([overnight], DAY);
+    expect(hours(busy)).toEqual(['09:00-10:00']);
+    expect(hours(free)).toEqual(['10:00-17:00']);
+  });
+
+  test('a fully booked window has no free time', () => {
+    const { free } = calculateFreeBusy([meeting(9, 17)], DAY);
+    expect(free).toEqual([]);
+  });
+
+  test('TRANSPARENT events do not block time', () => {
+    const { busy, free } = calculateFreeBusy([meeting(12, 13, ['TRANSP:TRANSPARENT'])], DAY);
+    expect(busy).toEqual([]);
+    expect(hours(free)).toEqual(['09:00-17:00']);
+  });
+
+  test('OPAQUE is explicit busy', () => {
+    const { busy } = calculateFreeBusy([meeting(12, 13, ['TRANSP:OPAQUE'])], DAY);
+    expect(hours(busy)).toEqual(['12:00-13:00']);
+  });
+
+  test('cancelled events do not block time', () => {
+    const { busy } = calculateFreeBusy([meeting(12, 13, ['STATUS:CANCELLED'])], DAY);
+    expect(busy).toEqual([]);
+  });
+
+  test('an all-day event blocks the UTC day it covers, whatever the host zone', () => {
+    const allDay = object([
+      'DTSTART;VALUE=DATE:20260525',
+      'DTEND;VALUE=DATE:20260526',
+      'SUMMARY:Conference',
+    ]);
+    const { busy, free } = calculateFreeBusy([allDay], DAY);
+    expect(hours(busy)).toEqual(['09:00-17:00']);
+    expect(free).toEqual([]);
+  });
+
+  test('an unparseable object is skipped rather than taking the answer down', () => {
+    const broken = { url: 'u', etag: '"1"', data: 'this is not iCalendar' };
+    const { busy } = calculateFreeBusy([broken, meeting(12, 13)], DAY);
+    expect(hours(busy)).toEqual(['12:00-13:00']);
+  });
+});
+
+describe('recurring events', () => {
+  const daily = object([
+    'DTSTART:20260101T100000Z',
+    'DTEND:20260101T110000Z',
+    'SUMMARY:Daily standup',
+    'RRULE:FREQ=DAILY',
+  ]);
+
+  test('an occurrence inside the window blocks it', () => {
+    const { busy } = calculateFreeBusy([daily], DAY);
+    expect(hours(busy)).toEqual(['10:00-11:00']);
+  });
+
+  test('every occurrence in a multi-day window is counted', () => {
+    const week = {
+      start: new Date('2026-05-25T00:00:00Z'),
+      end: new Date('2026-05-28T00:00:00Z'),
+    };
+    const { busy } = calculateFreeBusy([daily], week);
+    expect(busy).toHaveLength(3);
+  });
+
+  test('EXDATE removes an occurrence', () => {
+    const withExdate = object([
+      'DTSTART:20260101T100000Z',
+      'DTEND:20260101T110000Z',
+      'SUMMARY:Daily standup',
+      'RRULE:FREQ=DAILY',
+      'EXDATE:20260525T100000Z',
+    ]);
+    const { busy } = calculateFreeBusy([withExdate], DAY);
+    expect(busy).toEqual([]);
+  });
+
+  test('a degenerate series does not stall the calculation', () => {
+    const minutely = object([
+      'DTSTART:19700101T000000Z',
+      'DTEND:19700101T000100Z',
+      'SUMMARY:Pathological',
+      'RRULE:FREQ=MINUTELY',
+    ]);
+    const started = process.hrtime.bigint();
+    calculateFreeBusy([minutely], DAY);
+    const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+    expect(elapsedMs).toBeLessThan(2000);
+  });
+});
+
+describe('freebusy_query tool', () => {
+  beforeEach(() => fetchCalendarObjects.mockReset());
+
+  const call = (args) => freeBusyQuery.handler({
+    time_range_start: '2026-05-25T09:00:00Z',
+    time_range_end: '2026-05-25T17:00:00Z',
+    ...args,
+  });
+
+  test('searches every calendar by default', async () => {
+    fetchCalendarObjects.mockResolvedValue([]);
+    const text = (await call({})).content[0].text;
+    expect(fetchCalendarObjects).toHaveBeenCalledTimes(2);
+    expect(text).toContain('**Scope**: 2 calendars');
+  });
+
+  test('can be restricted to one calendar', async () => {
+    fetchCalendarObjects.mockResolvedValue([]);
+    const text = (await call({ calendar_url: CALENDAR_URL })).content[0].text;
+    expect(fetchCalendarObjects).toHaveBeenCalledTimes(1);
+    expect(text).toContain('**Scope**: 1 calendar');
+  });
+
+  test('reports free slots with their duration', async () => {
+    fetchCalendarObjects.mockResolvedValue([meeting(12, 13)]);
+    const text = (await call({ calendar_url: CALENDAR_URL })).content[0].text;
+    expect(text).toContain('### Free (2)');
+    expect(text).toContain('(3h)');
+    expect(text).toContain('### Busy (1)');
+    expect(text).toContain('(1h)');
+  });
+
+  test('says so when nothing is free', async () => {
+    fetchCalendarObjects.mockResolvedValue([meeting(9, 17)]);
+    const text = (await call({ calendar_url: CALENDAR_URL })).content[0].text;
+    expect(text).toContain('No free time');
+  });
+
+  test('event details are off by default and available on request', async () => {
+    fetchCalendarObjects.mockResolvedValue([meeting(12, 13)]);
+    const withoutDetails = (await call({ calendar_url: CALENDAR_URL })).content[0].text;
+    expect(withoutDetails).not.toContain('Events behind the busy blocks');
+
+    fetchCalendarObjects.mockResolvedValue([meeting(12, 13)]);
+    const withDetails = (await call({
+      calendar_url: CALENDAR_URL,
+      include_event_details: true,
+    })).content[0].text;
+    expect(withDetails).toContain('Events behind the busy blocks');
+    expect(withDetails).toContain('Meeting');
+  });
+
+  test('an inverted range is rejected', async () => {
+    await expect(freeBusyQuery.handler({
+      time_range_start: '2026-05-25T17:00:00Z',
+      time_range_end: '2026-05-25T09:00:00Z',
+    })).rejects.toThrow(/must be after/);
+  });
+
+  test('an unknown calendar names the available ones', async () => {
+    await expect(call({ calendar_url: 'https://dav.example.com/calendars/user/nope/' }))
+      .rejects.toThrow(/Available calendar URLs/);
+  });
+});

--- a/src/formatters.js
+++ b/src/formatters.js
@@ -1003,3 +1003,62 @@ export function formatError(error, context = '') {
     }]
   };
 }
+
+/**
+ * Format a free/busy answer to LLM-friendly Markdown
+ *
+ * Free slots come first: the question behind this tool is almost always "when
+ * can I put something", not "what am I doing".
+ */
+export function formatFreeBusy({ busy, free, range, calendarCount = 1, events = null }) {
+  const scope = calendarCount === 1 ? '1 calendar' : `${calendarCount} calendars`;
+
+  let output = `## Free/Busy\n\n`;
+  output += `- **Window**: ${formatDateTime(ICAL.Time.fromJSDate(range.start, true))} to ${formatDateTime(ICAL.Time.fromJSDate(range.end, true))}\n`;
+  output += `- **Scope**: ${scope}\n\n`;
+
+  if (free.length === 0) {
+    output += `**No free time** in this window — it is fully booked.\n\n`;
+  } else {
+    output += `### Free (${free.length})\n\n`;
+    free.forEach(slot => {
+      output += `- ${formatInterval(slot)}\n`;
+    });
+    output += '\n';
+  }
+
+  if (busy.length === 0) {
+    output += `### Busy (0)\n\nNothing blocks this window.\n`;
+  } else {
+    output += `### Busy (${busy.length})\n\n`;
+    busy.forEach(slot => {
+      output += `- ${formatInterval(slot)}\n`;
+    });
+  }
+
+  if (events) {
+    output += `\n### Events behind the busy blocks (${events.length})\n\n`;
+    events.forEach((event, index) => {
+      output += `#### ${index + 1}. `;
+      output += formatEvent(event, 'Calendar').replace(/^## /, '') + '\n';
+    });
+  }
+
+  return {
+    content: [{
+      type: 'text',
+      text: output
+    }]
+  };
+}
+
+function formatInterval({ start, end }) {
+  const from = formatDateTime(ICAL.Time.fromJSDate(start, true));
+  const to = formatDateTime(ICAL.Time.fromJSDate(end, true));
+  const minutes = Math.round((end.getTime() - start.getTime()) / 60000);
+  const duration = minutes >= 60
+    ? `${Math.floor(minutes / 60)}h${minutes % 60 ? ` ${minutes % 60}m` : ''}`
+    : `${minutes}m`;
+
+  return `${from} → ${to} (${duration})`;
+}

--- a/src/tools/calendar/freebusy-query.js
+++ b/src/tools/calendar/freebusy-query.js
@@ -1,0 +1,86 @@
+import { tsdavManager } from '../../tsdav-client.js';
+import { validateInput, freeBusyQuerySchema } from '../../validation.js';
+import { formatFreeBusy } from '../../formatters.js';
+import { buildTimeRangeOptions } from '../shared/helpers.js';
+import { calculateFreeBusy } from '../shared/freebusy.js';
+
+/**
+ * Answer "when am I free?" from the events themselves.
+ *
+ * Deliberately not the native CalDAV free-busy-query REPORT: Google and iCloud
+ * do not answer it, Radicale never implemented it, and Nextcloud and Baikal
+ * have open bugs, so it fails on most of the servers people actually run.
+ * Deriving the answer from the events works everywhere at the cost of needing
+ * read access to the calendar.
+ */
+export const freeBusyQuery = {
+  name: 'freebusy_query',
+  description: 'Find free and busy time in a date range — use for "when am I free?", "am I available Tuesday afternoon?" or finding a slot for a new meeting. Searches all calendars unless one is given. Events marked TRANSPARENT (does not block time) and cancelled events are ignored; recurring events are expanded.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      time_range_start: {
+        type: 'string',
+        description: 'Start of the window to examine (ISO 8601, e.g. 2026-05-25T00:00:00Z). Required.',
+      },
+      time_range_end: {
+        type: 'string',
+        description: 'End of the window to examine (ISO 8601). Required.',
+      },
+      calendar_url: {
+        type: 'string',
+        description: 'Optional: restrict to one calendar. Omit to consider every calendar, which is usually what "am I free" means.',
+      },
+      include_event_details: {
+        type: 'boolean',
+        description: 'Optional: also list the events behind each busy block, with titles. Off by default — the answer to "when am I free" is the slots, not the meetings.',
+      },
+    },
+    required: ['time_range_start', 'time_range_end'],
+  },
+  handler: async (args) => {
+    const validated = validateInput(freeBusyQuerySchema, args);
+    const client = tsdavManager.getCalDavClient();
+    const calendars = await client.fetchCalendars();
+
+    let calendarsToSearch = calendars;
+    if (validated.calendar_url) {
+      const calendar = calendars.find(c => c.url === validated.calendar_url);
+      if (!calendar) {
+        const availableUrls = calendars.map(c => c.url).join('\n- ');
+        throw new Error(
+          `Calendar not found: ${validated.calendar_url}\n\n` +
+          `Available calendar URLs:\n- ${availableUrls}\n\n` +
+          `Tip: Omit calendar_url to consider all calendars.`
+        );
+      }
+      calendarsToSearch = [calendar];
+    }
+
+    const timeRangeOptions = buildTimeRangeOptions(
+      validated.time_range_start,
+      validated.time_range_end
+    );
+
+    let events = [];
+    for (const calendar of calendarsToSearch) {
+      const found = await client.fetchCalendarObjects({ calendar, ...timeRangeOptions });
+      events = events.concat(found);
+    }
+
+    const range = {
+      start: new Date(validated.time_range_start),
+      end: new Date(validated.time_range_end),
+    };
+
+    const { busy, free } = calculateFreeBusy(events, range);
+
+    return formatFreeBusy({
+      busy,
+      free,
+      range,
+      calendarCount: calendarsToSearch.length,
+      events: validated.include_event_details ? events : null,
+    });
+  },
+};

--- a/src/tools/calendar/index.js
+++ b/src/tools/calendar/index.js
@@ -10,6 +10,7 @@ export { updateEventFields } from './update-event-fields.js';
 export { updateEventRaw } from './update-event-raw.js';
 export { deleteEvent } from './delete-event.js';
 export { calendarQuery } from './calendar-query.js';
+export { freeBusyQuery } from './freebusy-query.js';
 export { makeCalendar } from './make-calendar.js';
 export { updateCalendar } from './update-calendar.js';
 export { deleteCalendar } from './delete-calendar.js';

--- a/src/tools/index.js
+++ b/src/tools/index.js
@@ -18,7 +18,7 @@ import * as todoTools from './todos/index.js';
  */
 export const tools = [
   // ================================
-  // CALENDAR TOOLS (11 tools)
+  // CALENDAR TOOLS (12 tools)
   // ================================
   calendarTools.listCalendars,
   calendarTools.listEvents,
@@ -27,6 +27,7 @@ export const tools = [
   calendarTools.updateEventRaw,
   calendarTools.deleteEvent,
   calendarTools.calendarQuery,
+  calendarTools.freeBusyQuery,
   calendarTools.makeCalendar,
   calendarTools.updateCalendar,
   calendarTools.deleteCalendar,

--- a/src/tools/shared/freebusy.js
+++ b/src/tools/shared/freebusy.js
@@ -1,0 +1,148 @@
+import ICAL from 'ical.js';
+
+/**
+ * Client-side free/busy calculation.
+ *
+ * The native CalDAV free-busy-query REPORT is barely supported in practice —
+ * Google and iCloud do not answer it, Radicale never implemented it, Nextcloud
+ * and Baikal have open bugs — so this derives the same answer from the events
+ * themselves, which every server can serve. The cost is needing read access to
+ * the calendar rather than only free/busy access, and more data on the wire.
+ */
+
+// An unbounded RRULE can produce occurrences forever; the range gives us an end
+// to walk to, but the walk from DTSTART to the range can still be long. See the
+// equivalent cap in src/formatters.js.
+const MAX_RECURRENCE_ITERATIONS = 10000;
+
+/**
+ * Busy intervals contributed by a single calendar object.
+ *
+ * Skips anything that does not actually occupy time: TRANSP:TRANSPARENT is the
+ * RFC 5545 way of saying "this does not block me", and a cancelled event does
+ * not either. All-day events count as busy for their whole span.
+ */
+function busyIntervalsOf(calendarObject, range) {
+  const intervals = [];
+
+  let comp;
+  try {
+    comp = new ICAL.Component(ICAL.parse(calendarObject.data));
+  } catch {
+    // A single unparseable object must not take the whole answer down
+    return intervals;
+  }
+
+  const vevents = comp.getAllSubcomponents('vevent');
+  const master = vevents.find(v => !v.getFirstProperty('recurrence-id')) || vevents[0];
+  if (!master) return intervals;
+
+  const transparency = master.getFirstPropertyValue('transp');
+  const status = master.getFirstPropertyValue('status');
+  if (transparency === 'TRANSPARENT' || status === 'CANCELLED') return intervals;
+
+  const event = new ICAL.Event(master);
+  for (const override of vevents) {
+    if (override !== master && override.getFirstProperty('recurrence-id')) {
+      event.relateException(override);
+    }
+  }
+
+  const add = (start, end) => {
+    const from = Math.max(toInstant(start), range.start.getTime());
+    const to = Math.min(toInstant(end), range.end.getTime());
+    if (to > from) intervals.push({ start: from, end: to });
+  };
+
+  if (!event.isRecurring()) {
+    add(event.startDate, event.endDate);
+    return intervals;
+  }
+
+  const expansion = new ICAL.RecurExpansion({
+    component: master,
+    dtstart: event.startDate,
+  });
+
+  const rangeEnd = ICAL.Time.fromJSDate(range.end, true);
+  for (let step = 0; step < MAX_RECURRENCE_ITERATIONS; step++) {
+    const next = expansion.next();
+    if (!next || next.compare(rangeEnd) > 0) break;
+
+    const occurrence = event.getOccurrenceDetails(next);
+    add(occurrence.startDate, occurrence.endDate);
+  }
+
+  return intervals;
+}
+
+/**
+ * Absolute instant for an ICAL.Time.
+ *
+ * A date-only value is floating — "the 25th, wherever you are" — and has no
+ * instant of its own. toJSDate() would resolve it against whatever zone the
+ * server happens to run in, which makes the same query answer differently in
+ * Berlin and in Auckland. Reading the fields as UTC is at least deterministic:
+ * an all-day event blocks the UTC day. The alternative would be to guess a
+ * zone, and a wrong guess is worse than a stated convention.
+ */
+function toInstant(icalTime) {
+  if (icalTime.isDate) {
+    return Date.UTC(icalTime.year, icalTime.month - 1, icalTime.day);
+  }
+  return icalTime.toJSDate().getTime();
+}
+
+/**
+ * Merge overlapping and touching intervals into a minimal set.
+ */
+function mergeIntervals(intervals) {
+  if (intervals.length === 0) return [];
+
+  const sorted = [...intervals].sort((a, b) => a.start - b.start);
+  const merged = [{ ...sorted[0] }];
+
+  for (const interval of sorted.slice(1)) {
+    const last = merged[merged.length - 1];
+    // touching counts as overlapping: back-to-back meetings are one busy block,
+    // not two with a zero-length gap between them
+    if (interval.start <= last.end) {
+      last.end = Math.max(last.end, interval.end);
+    } else {
+      merged.push({ ...interval });
+    }
+  }
+
+  return merged;
+}
+
+/**
+ * Compute busy and free intervals for a set of calendar objects.
+ *
+ * @param {Array} calendarObjects - DAV objects with a `data` property
+ * @param {{ start: Date, end: Date }} range
+ * @returns {{ busy: Array<{start: Date, end: Date}>, free: Array<{start: Date, end: Date}> }}
+ */
+export function calculateFreeBusy(calendarObjects, range) {
+  const busy = mergeIntervals(
+    calendarObjects.flatMap(object => busyIntervalsOf(object, range))
+  );
+
+  const free = [];
+  let cursor = range.start.getTime();
+
+  for (const interval of busy) {
+    if (interval.start > cursor) {
+      free.push({ start: new Date(cursor), end: new Date(interval.start) });
+    }
+    cursor = Math.max(cursor, interval.end);
+  }
+  if (cursor < range.end.getTime()) {
+    free.push({ start: new Date(cursor), end: new Date(range.end) });
+  }
+
+  return {
+    busy: busy.map(i => ({ start: new Date(i.start), end: new Date(i.end) })),
+    free,
+  };
+}

--- a/src/validation.js
+++ b/src/validation.js
@@ -234,6 +234,16 @@ export const calendarQuerySchema = z.object({
   message: "Provide: (time_range with BOTH dates) OR (text filter) OR (both)"
 });
 
+export const freeBusyQuerySchema = z.object({
+  time_range_start: dateTimeWithOptionalOffset,
+  time_range_end: dateTimeWithOptionalOffset,
+  calendar_url: optionalUrl('Invalid calendar URL'),
+  include_event_details: z.boolean().optional(),
+}).refine((data) => new Date(data.time_range_end) > new Date(data.time_range_start), {
+  message: 'time_range_end must be after time_range_start',
+  path: ['time_range_end'],
+});
+
 export const makeCalendarSchema = z.object({
   display_name: z.string().min(1, 'Display name is required').max(200),
   description: z.string().max(500).optional(),


### PR DESCRIPTION
Answers "when am I free?", "am I available Tuesday afternoon?" and "find me a slot" — by deriving free and busy blocks from the events themselves.

## Why not the native REPORT

Following the design in #36: the CalDAV `free-busy-query` REPORT fails on most servers people actually run — Google and iCloud do not answer it, Radicale never implemented it (their issue has been open since 2013), Nextcloud and Baikal have open bugs — and tsdav's own docs warn against it. Calculating from events works everywhere.

The cost, stated plainly: this needs read access to the calendar rather than only free/busy access, and moves more data.

One correction to the issue's premise: tsdav *does* export `freeBusyQuery`, it is simply not on the client prototype. It would still be the wrong call for the reasons above.

## Behaviour

- `TRANSP:TRANSPARENT` — the RFC 5545 way of saying "this does not block me" — and cancelled events do not count as busy
- recurring series are expanded across the whole window, EXDATE honoured, with the same iteration cap the formatter uses so a degenerate RRULE cannot stall the answer
- **touching intervals merge**: back-to-back meetings are one busy block, not two with a zero-length gap of "free" time between them
- events are clipped to the window
- an unparseable object is skipped rather than taking the whole answer down
- free slots are listed first, with durations — the question is where something fits, not what you are doing

All calendars are searched unless one is named, since "am I free" rarely means one calendar. `include_event_details` is off by default.

## All-day events

They are floating values with no instant of their own. Resolving them through `toJSDate()` makes the same query answer differently depending on where the server runs — under `TZ=Pacific/Auckland` an all-day event covered only part of a UTC business day. They now resolve as UTC days, which is at least deterministic; guessing a zone and guessing wrong is worse than a stated convention. The suite runs from Pacific/Midway to Pacific/Auckland to hold this.

## Example

```
## Free/Busy

- **Window**: May 25, 2026, 09:00 AM UTC to May 25, 2026, 05:00 PM UTC
- **Scope**: 2 calendars

### Free (3)

- May 25, 2026, 09:00 AM UTC → May 25, 2026, 10:00 AM UTC (1h)
- May 25, 2026, 11:00 AM UTC → May 25, 2026, 02:00 PM UTC (3h)
- May 25, 2026, 03:00 PM UTC → May 25, 2026, 05:00 PM UTC (2h)

### Busy (2)

- May 25, 2026, 10:00 AM UTC → May 25, 2026, 11:00 AM UTC (1h)
- May 25, 2026, 02:00 PM UTC → May 25, 2026, 03:00 PM UTC (1h)
```

235 tests passing, up from 212. The interval logic is pure and carries the bulk of them.

Closes #36