### PR TITLE
fix: stop doubling the word in success messages

### DIFF
--- a/__tests__/delete-failures.test.js
+++ b/__tests__/delete-failures.test.js
@@ -89,3 +89,19 @@ describe('a successful delete still succeeds', () => {
     await expect(deleteCalendar.handler({ calendar_url: CALENDAR_URL })).resolves.toBeDefined();
   });
 });
+
+describe('success messages read as English', () => {
+  test('a create message is not doubled', async () => {
+    deleteObject.mockResolvedValue(davResponse(204));
+    const text = (await deleteCalendar.handler({ calendar_url: CALENDAR_URL })).content[0].text;
+    expect(text).not.toMatch(/successfully successful/);
+  });
+
+  test('formatSuccess does not append a second success word', async () => {
+    const { formatSuccess } = await import('../src/formatters.js');
+    const text = formatSuccess('Todo created successfully', { url: 'https://example.com/t.ics' })
+      .content[0].text;
+    expect(text).toContain('✅ **Todo created successfully**');
+    expect(text).not.toContain('successful**');
+  });
+});

--- a/src/formatters.js
+++ b/src/formatters.js
@@ -754,7 +754,10 @@ export function formatAddressBookList(addressBooks) {
  * Format success message for create/update/delete operations
  */
 export function formatSuccess(operation, details = {}) {
-  let output = `✅ **${operation} successful**\n\n`;
+  // Callers pass a complete phrase ("Todo created successfully"); appending a
+  // second "successful" here produced "created successfully successful" in
+  // every write response the model reads back.
+  let output = `✅ **${operation}**\n\n`;
 
   if (details.url) {
     output += `- **URL**: ${details.url}\n`;


### PR DESCRIPTION
Every caller passes a complete phrase — `formatSuccess('Todo created successfully', …)` — and the formatter appended `" successful"` on top, so every write returned:

```
✅ **Todo created successfully successful**
```

Cosmetic, but it sits in the first line of every create, update and delete response the model reads back. Fixed in the formatter rather than in the thirteen call sites, since their phrasing is the correct one.

Spotted while verifying the todo tools against a live Baikal server.

237 tests passing.