### PR TITLE
chore(release): 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,97 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0] - 2026-08-14
+
+A correctness release. Several tools returned confidently wrong answers or
+accepted input that produced invalid objects on the server; the fixes change
+behaviour, hence the major version.
+
+### Breaking Changes
+
+- **`update_event` no longer takes dates through `fields`.** `DTSTART`, `DTEND`
+  and `DURATION` are rejected there; use the new top-level `start_date`,
+  `end_date` and `all_day` parameters instead (#56). The flat map cannot express
+  this property family: an all-day value needs a `VALUE=DATE` parameter, which
+  the map could only add as a *duplicate* property, and writing `DTEND` on an
+  event stored as `DTSTART` + `DURATION` left both present, which RFC 5545 3.6.1
+  forbids.
+- **The `fields` map of `update_event`, `update_todo` and `update_contact` now
+  validates its keys and values** (#44). Keys must be bare property names and
+  values must be single-line. Parameterised keys (`DTSTART;VALUE=DATE`) and
+  multi-line values are rejected.
+- **Query tools return at most 20 results by default** (#34). `calendar_query`,
+  `todo_query` and `addressbook_query` previously returned everything in range.
+  Pass `limit` (max 500) to raise it; the response states how many matched in
+  total.
+
+### Security
+
+- **Property and component injection through the `fields` map** (#44). Keys and
+  values reached `updatePropertyWithValue` unvalidated, and that function keys on
+  the property *name* alone. A value could terminate the VEVENT and open a
+  second, fully caller-shaped one; a key containing `:` or a line break injected
+  properties outright; a `VALARM` with `ACTION:EMAIL` and an arbitrary attendee
+  could be attached. Verified by re-parsing the emitted documents. Reachable
+  through ordinary tool arguments, which matters here because the caller is a
+  model that routinely handles untrusted text.
+- **Carriage returns survived `sanitizeICalString`**, and `create_event` and
+  `create_contact` emitted LF line endings where RFC 5545 3.1 and RFC 6350 3.2
+  require CRLF (#47).
+
+### Fixed
+
+- **Recurring events showed the series start, not the occurrence in the queried
+  range** (#45). "What's on next week" returned each series once, dated at its
+  original start — often years back. Present with a wrong date is worse than
+  absent. Expansion is client-side, so it does not depend on a server
+  implementing `CALDAV:expand`, and it also surfaces `RECURRENCE-ID` overrides,
+  which were silently dropped. The walk is capped so a degenerate `RRULE` cannot
+  stall a response.
+- **Times were rendered in the server's timezone, not the event's** (#46). A
+  meeting booked for 14:00 Berlin showed as 12:00 on a UTC host. An
+  Exchange-style TZID made the date vanish entirely, and date-only values shifted
+  a day east of Greenwich. Unresolvable TZIDs now render from the offset in the
+  object's own VTIMEZONE (#54).
+- **Deletes reported success even when the server refused them** (#9). `fetch`
+  does not reject on 4xx, and the Response was discarded, so a 403 looked exactly
+  like a 204. Server-independent, contrary to the issue's Radicale framing.
+- **`[object Object]` as the collection name** (#38), across five call sites plus
+  an explicit `null` path that a default parameter does not catch.
+- **Contact photos overflowed the context** (#33). One contact with an embedded
+  `PHOTO` produced ~171k characters, 99.9% of it base64 echoed into the raw data
+  block. Against a real address book: 456k characters of raw cards render in 8.9k.
+- **`client.fetchTodos is not a function`** (#41). The fork's committed `dist/`
+  had lost the whole VTODO surface to an upstream sync, and a git install never
+  rebuilt it, so six of the eight todo tools were dead for npm users while
+  working locally. Fixed in the fork; the pin moves to that build and a test now
+  asserts the client exposes what this server calls.
+- **The tool-call logger could corrupt the JSON-RPC stream** (#48) by writing to
+  stdout under the stdio transport.
+- Success messages no longer read "created successfully successful".
+
 ### Added
+
+- **`freebusy_query`** (#36): answers "when am I free?" client-side, since the
+  native CalDAV `free-busy-query` REPORT fails on most servers people run.
+  `TRANSP:TRANSPARENT` and cancelled events do not block; recurring series are
+  expanded; touching intervals merge.
 - **All-day events** (#43): `create_event` and `update_event` accept a bare
   `YYYY-MM-DD` `start_date`/`end_date` (or an explicit `all_day` flag) and emit
   `DTSTART;VALUE=DATE` / `DTEND;VALUE=DATE`. `update_event` gained top-level
   `start_date`/`end_date`/`all_day` parameters, which convert an event in both
   directions; the `fields` map cannot express a parameterised property.
   The all-day `DTEND` is exclusive, as RFC 5545 3.8.2.2 requires.
+- **`limit`** on the three query tools, with the result set sorted before
+  truncation so the subset is the earliest rather than arbitrary (#34, #32).
+
+### Internal
+
+- Tests: 76 → 237, including the first formatter, handler and timezone coverage.
+  The suite runs under host timezones from Pacific/Midway to Pacific/Auckland,
+  which is where the date-shifting bugs hid.
+- Removed `src/utils/tool-helpers.js` (no importers, duplicated
+  `src/tools/shared/helpers.js`).
 
 ## [3.0.1] - 2026-01-20
 

--- a/README.md
+++ b/README.md
@@ -85,24 +85,25 @@ When partial tools force your AI to improvise, complete tools let it **execute p
 
 | Capability | dav-mcp | Most MCPs |
 |------------|---------|-----------|
-| **Calendar Management** | Full CRUD (11 tools) | Create + list only (2-3 tools) |
+| **Calendar Management** | Full CRUD (12 tools) | Create + list only (2-3 tools) |
 | **Contact Management** | Complete CardDAV (8 tools) | Often missing entirely |
 | **Task Management** | Full VTODO support (7 tools) | Rarely included |
 | **Field-Based Updates** | All RFC properties + custom fields | Rarely available |
+| **Free/Busy** | Works on every server (client-side) | Native REPORT, unsupported by most |
 | **Server-Side Filtering** | Efficient queries | Dumps all data |
 | **Multi-Provider** | Any CalDAV/CardDAV server | Limited provider support |
-| **Total Tools** | **26 tools** | **2-6 tools** |
+| **Total Tools** | **27 tools** | **2-6 tools** |
 
 ---
 
-## Available Tools (26 Total)
+## Available Tools (27 Total)
 
-### CalDAV Tools (11 tools)
+### CalDAV Tools (12 tools)
 
 1. **list_calendars** - List all available calendars
 2. **list_events** - List ALL events (use calendar_query for filtered searches)
 3. **create_event** - Create a new calendar event
-4. **update_event** - PREFERRED: Update any event field (SUMMARY, LOCATION, DTSTART, STATUS, custom X-* properties)
+4. **update_event** - PREFERRED: Update any event field (SUMMARY, LOCATION, STATUS, custom X-* properties); move or convert an event with start_date/end_date/all_day
 5. **update_event_raw** - Update event with raw iCal data (advanced)
 6. **delete_event** - Delete an event permanently
 7. **calendar_query** - PREFERRED: Search and filter events efficiently by text, date range, or location
@@ -110,6 +111,7 @@ When partial tools force your AI to improvise, complete tools let it **execute p
 9. **update_calendar** - Update calendar properties (display name, description, color, timezone)
 10. **delete_calendar** - Permanently delete a calendar and all its events
 11. **calendar_multi_get** - Batch fetch multiple specific events by URLs
+12. **freebusy_query** - Find free and busy time in a range ("when am I free?"), calculated client-side
 
 ### CardDAV Tools (8 tools)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dav-mcp",
-  "version": "3.0.7",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dav-mcp",
-      "version": "3.0.7",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dav-mcp",
-  "version": "3.0.7",
+  "version": "4.0.0",
   "mcpName": "io.github.PhilflowIO/dav-mcp",
   "description": "Complete DAV integration for AI - Calendar (CalDAV), Contacts (CardDAV), and Tasks (VTODO) management via MCP protocol",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.PhilflowIO/dav-mcp",
-  "description": "AI-orchestrated calendars, contacts & tasks across any DAV platform. 26 tools, field-agnostic.",
+  "description": "AI-orchestrated calendars, contacts & tasks across any DAV platform. 27 tools, field-agnostic.",
   "repository": {
     "url": "https://github.com/PhilflowIO/dav-mcp",
     "source": "github"
   },
-  "version": "3.0.7",
+  "version": "4.0.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "dav-mcp",
-      "version": "3.0.7",
+      "version": "4.0.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Release prep for everything merged today. No source changes — version, changelog, tool counts.

## Why 4.0.0 and not 3.1.0

Three changes alter behaviour for an existing caller:

1. `update_event` no longer accepts `DTSTART`/`DTEND`/`DURATION` through `fields` (#56)
2. the `fields` map now validates keys and values, rejecting parameterised keys and multi-line values (#44)
3. query tools cap at **20 results** by default where they previously returned everything (#34)

The third is the decisive one. The first two produce a clear validation error that a model reads and adapts to — an argument for treating MCP tool schemas as loosely versioned. But a silent cap on *results* is exactly the kind of change a caller cannot detect by reading the schema, and any automation that assumed a full result set now gets twenty. That deserves a major version as a signal, and a changelog entry someone can find.

## Contents

- `package.json`, `package-lock.json`, `server.json` → 4.0.0
- `server.json` description and README → 27 tools (was 26; `freebusy_query` is new)
- README: `freebusy_query` listed, `update_event` line corrected to point at `start_date`/`end_date`/`all_day` rather than `DTSTART`
- CHANGELOG: full entry with breaking changes, security, fixes and additions

237 tests passing.

## After merge

`publish-registry.yml` publishes to the MCP registry on GitHub release, via OIDC — that one is automatic. There is **no** npm publish workflow, and `npm whoami` is unauthenticated here, so the npm side needs your credentials: `npm publish` from a clean checkout of the tag.