### PR TITLE
fix: keep dotenv off stdout and report the real version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **dotenv printed a banner to stdout under the stdio transport**, so the first
+  thing a strict MCP client read was not JSON-RPC. Same hazard as #48, from a
+  dependency rather than our own code.
+- **The version reported to clients was hardcoded** and still said `3.0.1` in
+  five places. It now comes from `package.json`, with a protocol-level test that
+  speaks to the real server over stdio and asserts the two agree.
+
 ## [4.0.0] - 2026-08-14
 
 A correctness release. Several tools returned confidently wrong answers or

--- a/__tests__/stdio-protocol.test.js
+++ b/__tests__/stdio-protocol.test.js
@@ -1,0 +1,59 @@
+import { describe, test, expect } from '@jest/globals';
+import { spawn } from 'child_process';
+import { readFileSync } from 'fs';
+
+const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+
+// Under the stdio transport, stdout carries JSON-RPC and nothing else. Anything
+// else printed there — a dotenv banner, a stray console.log — makes a strict
+// client fail on the first message, which is invisible in unit tests.
+const speak = (messages) => new Promise((resolve, reject) => {
+  const child = spawn(process.execPath, ['src/server-stdio.js'], {
+    env: {
+      ...process.env,
+      MCP_TRANSPORT: 'stdio',
+      CALDAV_SERVER_URL: 'https://example.invalid',
+      CALDAV_USERNAME: 'x',
+      CALDAV_PASSWORD: 'y',
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  let stdout = '';
+  child.stdout.on('data', d => { stdout += d; });
+  child.on('error', reject);
+
+  messages.forEach(m => child.stdin.write(JSON.stringify(m) + '\n'));
+
+  setTimeout(() => {
+    child.kill();
+    resolve(stdout.trim().split('\n').filter(Boolean));
+  }, 4000);
+});
+
+const INITIALIZE = {
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'initialize',
+  params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'test', version: '1' } },
+};
+
+describe('stdio transport keeps stdout clean', () => {
+  test('every line on stdout is valid JSON-RPC', async () => {
+    const lines = await speak([INITIALIZE, { jsonrpc: '2.0', id: 2, method: 'tools/list' }]);
+    expect(lines.length).toBeGreaterThan(0);
+    lines.forEach(line => expect(() => JSON.parse(line)).not.toThrow());
+  }, 20000);
+
+  test('the version reported to clients matches package.json', async () => {
+    const [first] = await speak([INITIALIZE]);
+    expect(JSON.parse(first).result.serverInfo.version).toBe(packageJson.version);
+  }, 20000);
+
+  test('every registered tool is advertised', async () => {
+    const lines = await speak([INITIALIZE, { jsonrpc: '2.0', id: 2, method: 'tools/list' }]);
+    const listed = lines.map(l => JSON.parse(l)).find(m => m.id === 2);
+    const { tools } = await import('../src/tools/index.js');
+    expect(listed.result.tools).toHaveLength(tools.length);
+  }, 20000);
+});

--- a/src/server-http.js
+++ b/src/server-http.js
@@ -18,6 +18,7 @@
  */
 
 import express from 'express';
+import { SERVER_NAME, SERVER_VERSION } from './server-info.js';
 import cors from 'cors';
 import crypto from 'crypto';
 import dotenv from 'dotenv';
@@ -174,8 +175,8 @@ function createMCPServer(requestId) {
 
   const server = new Server(
     {
-      name: process.env.MCP_SERVER_NAME || 'dav-mcp',
-      version: process.env.MCP_SERVER_VERSION || '3.0.1',
+      name: SERVER_NAME,
+      version: SERVER_VERSION,
     },
     {
       capabilities: {
@@ -309,8 +310,8 @@ app.delete('/mcp', (req, res) => {
 app.get('/health', (req, res) => {
   res.json({
     status: 'healthy',
-    server: process.env.MCP_SERVER_NAME || 'dav-mcp',
-    version: process.env.MCP_SERVER_VERSION || '3.0.1',
+    server: SERVER_NAME,
+    version: SERVER_VERSION,
     transport: 'http-stateless',
     timestamp: new Date().toISOString(),
     tools: tools.length,
@@ -323,8 +324,8 @@ app.get('/health', (req, res) => {
  */
 app.get('/', (req, res) => {
   res.json({
-    name: process.env.MCP_SERVER_NAME || 'dav-mcp',
-    version: process.env.MCP_SERVER_VERSION || '3.0.1',
+    name: SERVER_NAME,
+    version: SERVER_VERSION,
     transport: 'http-stateless',
     description: 'MCP Streamable HTTP Server for CalDAV/CardDAV integration (stateless)',
     endpoints: {

--- a/src/server-info.js
+++ b/src/server-info.js
@@ -1,0 +1,17 @@
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+/**
+ * The version we report to MCP clients.
+ *
+ * Read from package.json rather than hardcoded: the literal sat in five places
+ * and still said 3.0.1 after two releases, so every client was told the wrong
+ * version.
+ */
+const packageJson = JSON.parse(
+  readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'package.json'), 'utf8')
+);
+
+export const SERVER_NAME = process.env.MCP_SERVER_NAME || packageJson.name;
+export const SERVER_VERSION = process.env.MCP_SERVER_VERSION || packageJson.version;

--- a/src/server-stdio.js
+++ b/src/server-stdio.js
@@ -57,9 +57,12 @@ async function startStdioServer() {
   const { createToolErrorResponse, MCP_ERROR_CODES } = await import('./error-handler.js');
   const { logger } = await import('./logger.js');
   const { initializeToolCallLogger, getToolCallLogger } = await import('./tool-call-logger.js');
+  const { SERVER_NAME, SERVER_VERSION } = await import('./server-info.js');
 
-  // Load environment variables
-  dotenv.default.config();
+  // Load environment variables. quiet: true because dotenv otherwise prints a
+  // banner to STDOUT, which under this transport is the JSON-RPC channel — a
+  // strict client fails to parse the first message.
+  dotenv.default.config({ quiet: true });
 
   /**
    * Initialize tsdav clients based on auth method
@@ -111,8 +114,8 @@ async function startStdioServer() {
   function createMCPServer(ensureInit) {
     const server = new Server(
       {
-        name: process.env.MCP_SERVER_NAME || 'dav-mcp',
-        version: process.env.MCP_SERVER_VERSION || '3.0.1',
+        name: SERVER_NAME,
+        version: SERVER_VERSION,
       },
       {
         capabilities: {
@@ -220,8 +223,8 @@ async function startStdioServer() {
     await server.connect(transport);
 
     logger.info({
-      name: process.env.MCP_SERVER_NAME || 'dav-mcp',
-      version: process.env.MCP_SERVER_VERSION || '3.0.1',
+      name: SERVER_NAME,
+      version: SERVER_VERSION,
       tools: tools.length,
     }, 'dav-mcp STDIO server ready');
 


### PR DESCRIPTION
Found by packing the 4.0.0 tarball, installing it into a clean directory and speaking MCP to it — not by the unit tests, which cannot see either of these.

## dotenv wrote to stdout

Under the stdio transport, stdout carries JSON-RPC and nothing else. dotenv prints a banner there:

```
[dotenv@17.2.3] injecting env (0) from .env -- tip: ⚙️ suppress all logs with { quiet: true }
{"result":{"protocolVersion":"2024-11-05",...
```

So the first thing a strict client reads is not a message. Exactly the hazard we fixed for our own tool-call logger in #48, this time arriving from a dependency. `quiet: true` silences it.

## The version was a stale literal

`serverInfo.version` was `process.env.MCP_SERVER_VERSION || '3.0.1'` — hardcoded in **five** places and never updated, so every client has been told 3.0.1 since the 3.0.2 release. It now comes from `package.json` through one small module, together with the server name, so it cannot drift again.

## Test

A protocol-level test spawns the real server over stdio and asserts that every line on stdout parses as JSON, that the reported version matches `package.json`, and that the advertised tool count matches the registry. Verified it fails without the fix.

240 tests passing.

**This should go out before 4.0.0 is published** — the stdout bug affects every stdio client, which is the default transport.