### PR TITLE
feat(docker): distroless nonroot runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ COPY src ./src
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD ["node", "-e", "require('http').get('http://localhost:3000/health', (r) => { process.exit(r.statusCode === 200 ? 0 : 1); }).on('error', () => process.exit(1));"]
+    CMD ["/nodejs/bin/node", "-e", "require('http').get('http://localhost:3000/health', (r) => { process.exit(r.statusCode === 200 ? 0 : 1); }).on('error', () => process.exit(1));"]
 
 CMD ["src/server-http.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,22 +7,15 @@ COPY package*.json ./
 RUN --mount=type=cache,target=/root/.npm \
     npm ci --omit=dev
 
-FROM node:22-alpine AS runtime
+FROM gcr.io/distroless/nodejs22-debian12 AS runtime
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY package.json ./
 COPY src ./src
 
-# Create non-root user
-RUN addgroup -g 1001 -S nodejs && \
-    adduser -S nodejs -u 1001 && \
-    chown -R nodejs:nodejs /app
-
-USER nodejs
-
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD node -e "require('http').get('http://localhost:3000/health', (r) => { process.exit(r.statusCode === 200 ? 0 : 1); }).on('error', () => process.exit(1));"
+    CMD ["node", "-e", "require('http').get('http://localhost:3000/health', (r) => { process.exit(r.statusCode === 200 ? 0 : 1); }).on('error', () => process.exit(1));"]
 
-CMD ["node", "src/server-http.js"]
+CMD ["src/server-http.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN --mount=type=cache,target=/root/.npm \
     npm ci --omit=dev
 
 FROM gcr.io/distroless/nodejs22-debian12:nonroot AS runtime
+ENV NODE_ENV=production
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY package.json ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY package*.json ./
 RUN --mount=type=cache,target=/root/.npm \
     npm ci --omit=dev
 
-FROM gcr.io/distroless/nodejs22-debian12 AS runtime
+FROM gcr.io/distroless/nodejs22-debian12:nonroot AS runtime
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY package.json ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,34 @@
 # syntax=docker/dockerfile:1
 
+# Stage 1: install production dependencies. Alpine provides npm and the git
+# required by the tsdav/tsdav-utils git dependencies in package.json.
 FROM node:22-alpine AS deps
 WORKDIR /app
 RUN apk add --no-cache git
+# Copy package files
 COPY package*.json ./
 RUN --mount=type=cache,target=/root/.npm \
     npm ci --omit=dev
 
+# Stage 2: minimal runtime image (distroless: non-root user, no shell, no package manager).
+# Non-root is provided by the distroless :nonroot variant (uid 65532).
 FROM gcr.io/distroless/nodejs22-debian12:nonroot AS runtime
+# Runtime config via env vars; NODE_ENV selects Express production mode.
+# Overridable at runtime: PORT (default 3000), BEARER_TOKEN, CALDAV_SERVER_URL,
+# CALDAV_USERNAME, CALDAV_PASSWORD, CORS_ALLOWED_ORIGINS.
 ENV NODE_ENV=production
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY package.json ./
+# Copy source code
 COPY src ./src
 
 EXPOSE 3000
 
+# Health check (exec form; no shell in distroless). node is not on PATH in
+# distroless, so the absolute binary path is required.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD ["/nodejs/bin/node", "-e", "require('http').get('http://localhost:3000/health', (r) => { process.exit(r.statusCode === 200 ? 0 : 1); }).on('error', () => process.exit(1));"]
 
+# Start server (HTTP mode for Docker/remote deployments)
 CMD ["src/server-http.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
-FROM node:22-alpine
+# syntax=docker/dockerfile:1
 
+FROM node:22-alpine AS deps
 WORKDIR /app
-
-# Copy package files
+RUN apk add --no-cache git
 COPY package*.json ./
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci --omit=dev
 
-# Install dependencies
-RUN npm ci --only=production
-
-# Copy source code
+FROM node:22-alpine AS runtime
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY package.json ./
 COPY src ./src
 
 # Create non-root user
@@ -18,12 +20,9 @@ RUN addgroup -g 1001 -S nodejs && \
 
 USER nodejs
 
-# Expose port
 EXPOSE 3000
 
-# Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD node -e "require('http').get('http://localhost:3000/health', (r) => { process.exit(r.statusCode === 200 ? 0 : 1); }).on('error', () => process.exit(1));"
 
-# Start server (HTTP mode for Docker/remote deployments)
 CMD ["node", "src/server-http.js"]


### PR DESCRIPTION
Move the runtime to `gcr.io/distroless/nodejs22-debian12:nonroot` after splitting the Dockerfile into deps + runtime stages (base: `node:22-alpine`).

- **Security:** runs as non-root (uid 65532); no shell, no package manager
- **Correctness:** healthcheck uses `/nodejs/bin/node` (node is not on PATH in distroless)
- **Runtime:** `NODE_ENV=production` baked in so direct image runs get Express prod mode

## Changes / maintenance surface

- [x] Multi-stage Dockerfile: `deps` stage (`node:22-alpine`) + `runtime` stage (distroless)
- [x] Base image pins: `node:22-alpine` (deps), `gcr.io/distroless/nodejs22-debian12:nonroot` (runtime)
- [x] Runtime env: `NODE_ENV=production` baked in; `PORT`, `BEARER_TOKEN`, `CALDAV_SERVER_URL`, `CALDAV_USERNAME`, `CALDAV_PASSWORD`, `CORS_ALLOWED_ORIGINS` overridable at runtime
- [x] Healthcheck: exec-form via `/nodejs/bin/node` (no shell on distroless; not on PATH)
- [x] Non-root execution (uid 65532) — `/app` itself is owned by uid 65532 (mode 755), only its `/app/src` contents are root-owned; a runtime write to `/app/src` fails with EACCES (writes to `/tmp` (1777) succeed). The container does **not** run with `--read-only`.
- [x] `npm ci --omit=dev` in deps stage with BuildKit cache mount; requires `package-lock.json` in sync
- [x] No `git` in the deps stage — `npm ci --omit=dev` resolves the `github:` tsdav/tsdav-utils dependencies as codeload tarballs, not over the git protocol
- [x] GHCR images will be built with this Dockerfile (docker format preserves `HEALTHCHECK`)

## Test / validation

- [x] `podman build --format docker` succeeds
- [x] Container boots against a live CalDAV backend (Radicale)
- [x] `/health` returns 200
- [x] Healthcheck reports `healthy` (`State.Health.status`, exit 0)
- [x] Runs as non-root (`Config.User` == 65532)
- [x] No shell present (`/bin/sh`, `/bin/bash` absent)
- [x] `NODE_ENV` resolves to `production` inside the image
- [x] Image size reduced: 622 MB (node:22-alpine single-stage) → 170 MB (−73%)

## Commits

- chore(docker): bump base image from node:18-alpine to node:22-alpine
- refactor(docker): split Dockerfile into deps and runtime stages
- feat(docker): switch runtime stage to distroless nodejs22-debian12
- fix(docker): use distroless nonroot variant
- fix(docker): use absolute node path in healthcheck
- fix(docker): set NODE_ENV=production in runtime stage
- docs(docker): restore step comments in Dockerfile
- fix(docker): healthcheck must respect PORT env and use distroless node path
- fix(docker): pin base images by digest
- chore(docker): remove unnecessary git install from deps stage
- fix(compose): drop broken healthcheck override for distroless

> Note: Podman's OCI image format silently drops `HEALTHCHECK`; all verification used `--format docker`, matching the docker-format images GHCR will publish.